### PR TITLE
Add goac notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .ipynb_checkpoints
+.github/copilot-instructions.md
+*.ipynb_checkpoints
+*.pyc
+__pycache__/
+.env
+.venv
+venv/

--- a/goac_integration_demo.ipynb
+++ b/goac_integration_demo.ipynb
@@ -1,0 +1,3366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GOAC Integration with GEMDAT\n",
+    "\n",
+    "This notebook demonstrates how to integrate **GOAC** (Global Optimization of Atomistic Configurations by Coulomb) with **GEMDAT** for atomistic configuration optimization. GOAC uses a Coulomb energy-based approach to find the lowest-energy arrangement of atoms in materials with partially occupied sites (e.g., solid electrolytes with disordered Li). The workflow is: **MD Trajectory → Site Occupancy Analysis (GEMDAT) → Configuration Optimization (GOAC)**.\n",
+    "\n",
+    "See the [installation instructions](https://gemdat.readthedocs.io/en/latest/install_goac.html) to set up GOAC before running this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import GOAC and GEMDAT\n",
+    "\n",
+    "This notebook requires GOAC to be installed. Refer to the [installation instructions](https://gemdat.readthedocs.io/en/latest/install_goac.html) to set up GOAC before running this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/simone/Dropbox/eScience_projects/NANO-DOME/GEMDAT/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import gemdat\n",
+    "from gemdat import Trajectory\n",
+    "\n",
+    "import plotly.io as pio\n",
+    "pio.renderers.default = 'vscode'\n",
+    "\n",
+    "try:\n",
+    "    import goac\n",
+    "    from goac import Random_Solver, Iteration_Problem\n",
+    "except ImportError:\n",
+    "    raise SystemExit(\n",
+    "        'GOAC is not installed. See https://gemdat.readthedocs.io/en/latest/install_goac.html'\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load MD Trajectory Data\n",
+    "\n",
+    "In this example, we load LAMMPS simulation data for a Li-In-Cl material (80 atoms per unit cell) with disordered Li sites. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading trajectory from LAMMPS files...\n",
+      "✓ Trajectory loaded!\n",
+      "  Formula: Li24 In8 Cl48\n",
+      "  Total atoms: 80\n",
+      "  Time steps: 4\n",
+      "  Time step: 2.0 ps\n",
+      "  Total time: 8.00e-12 s\n",
+      "\n",
+      "  Element distribution:\n",
+      "    Cl: 48 atoms\n",
+      "    In: 8 atoms\n",
+      "    Li: 24 atoms\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load LAMMPS trajectory data\n",
+    "# The notebook is in docs/notebooks, data is in tests/data/lammps\n",
+    "project_root = Path.cwd().parent.parent\n",
+    "data_dir = project_root / 'tests' / 'data' / 'lammps'\n",
+    "coords_file = data_dir / 'lammps_coords.xyz'\n",
+    "data_file = data_dir / 'lammps_data.txt'\n",
+    "\n",
+    "print('Loading trajectory from LAMMPS files...')\n",
+    "trajectory = Trajectory.from_lammps(\n",
+    "    coords_file=str(coords_file),\n",
+    "    data_file=str(data_file),\n",
+    "    temperature=700.0,\n",
+    "    time_step=2.0,  # ps\n",
+    ")\n",
+    "\n",
+    "print(f'✓ Trajectory loaded!')\n",
+    "first_structure = trajectory.get_structure(0)\n",
+    "print(f'  Formula: {first_structure.composition.formula}')\n",
+    "print(f'  Total atoms: {len(first_structure)}')\n",
+    "print(f'  Time steps: {len(trajectory)}')\n",
+    "print(f'  Time step: {trajectory.time_step_ps:.1f} ps')\n",
+    "print(f'  Total time: {trajectory.total_time:.2e} s')\n",
+    "\n",
+    "# Show element distribution\n",
+    "from collections import Counter\n",
+    "elements = [site.species.elements[0].symbol for site in first_structure.sites]\n",
+    "element_counts = Counter(elements)\n",
+    "print(f'\\n  Element distribution:')\n",
+    "for elem, count in sorted(element_counts.items()):\n",
+    "    print(f'    {elem}: {count} atoms')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze Li Occupancy with GEMDAT\n",
+    "\n",
+    "Compute Li site occupancies from the trajectory using GEMDAT's `transitions_between_sites`. This gives each Li site a fractional occupancy — the core input for GOAC. Fixed elements (In, Cl) keep full occupancy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analyzing Li transitions for site occupancies...\n",
+      "  Found 17 transition events\n",
+      "  Li sites being tracked: 80\n",
+      "\n",
+      "Occupancy structure: LiLi16.5\n",
+      "\n",
+      "  Li site occupancies (first 12 sites):\n",
+      "    Site 0: occupancy = 0.750\n",
+      "    Site 1: occupancy = 1.000\n",
+      "    Site 2: occupancy = 0.500\n",
+      "    Site 3: occupancy = 0.500\n",
+      "    Site 4: occupancy = 1.000\n",
+      "    Site 5: occupancy = 0.500\n",
+      "    Site 6: occupancy = 0.500\n",
+      "    Site 7: occupancy = 0.750\n",
+      "    Site 8: occupancy = 1.000\n",
+      "    Site 9: occupancy = 0.750\n",
+      "    Site 10: occupancy = 1.000\n",
+      "    Site 11: occupancy = 0.500\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Analyze Li transitions and get partial occupancies\n",
+    "first_structure = trajectory.get_structure(0)\n",
+    "\n",
+    "print('Analyzing Li transitions for site occupancies...')\n",
+    "transitions = trajectory.transitions_between_sites(\n",
+    "    sites=first_structure,\n",
+    "    floating_specie='Li',\n",
+    ")\n",
+    "\n",
+    "print(f'  Found {transitions.n_events} transition events')\n",
+    "print(f'  Li sites being tracked: {transitions.n_sites}')\n",
+    "\n",
+    "# Get the occupancy structure: each Li site gets a fractional occupancy (0..1)\n",
+    "occ_structure = transitions.occupancy()\n",
+    "print(f'\\nOccupancy structure: Li{occ_structure.composition.reduced_formula}')\n",
+    "\n",
+    "# Show Li occupancies\n",
+    "print(f'\\n  Li site occupancies (first 12 sites):')\n",
+    "for i, site in enumerate(occ_structure.sites[:12]):\n",
+    "    occ_val = site.species.num_atoms\n",
+    "    if occ_val > 0:\n",
+    "        print(f'    Site {i}: occupancy = {occ_val:.3f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a Structure with Partial Occupancies for GOAC\n",
+    "\n",
+    "Combine Li partial occupancies with full-occupancy In and Cl sites into a CIF file — the format GOAC expects. Each site gets a unique label with its charge (Li⁺ = +1, In³⁺ = +3, Cl⁻ = -1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Built input structure with 80 sites\n",
+      "  Formula: Li16.5 In8 Cl48\n",
+      "  Saved to /tmp/gemdat_goac_demo/li_in_cl_occupancy.cif\n",
+      "\n",
+      "Sample sites:\n",
+      "  Li1     : Li0.75      at (0.249, 0.347, 0.260)\n",
+      "  Li2     : Li          at (0.749, 0.347, 0.763)\n",
+      "  Li3     : Li0.5       at (0.755, 0.351, 0.248)\n",
+      "  Li4     : Li0.5       at (0.004, 0.836, 0.251)\n",
+      "  Li5     : Li          at (0.504, 0.849, 0.259)\n",
+      "  Li6     : Li0.5       at (0.000, 0.175, 0.253)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/simone/Dropbox/eScience_projects/NANO-DOME/GEMDAT/.venv/lib/python3.12/site-packages/pymatgen/core/composition.py:1373: FutureWarning: gcd is deprecated, and will be removed on 2028-01-01\n",
+      "Use math.gcd instead.\n",
+      "  factor = abs(gcd(*(int(i) for i in sym_amt.values())))\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "from pymatgen.core import Structure\n",
+    "import numpy as np\n",
+    "\n",
+    "# Get the first structure (all elements) and Li occupancies\n",
+    "first_structure = trajectory.get_structure(0)\n",
+    "occ_structure = transitions.occupancy()\n",
+    "\n",
+    "# Build a full structure with:\n",
+    "# - Li sites: partial occupancies from GEMDAT\n",
+    "# - In, Cl sites: full occupancy (1.0)\n",
+    "# - Unique labels for every site (GOAC requirement)\n",
+    "all_species = []\n",
+    "all_coords = []\n",
+    "all_labels = []\n",
+    "\n",
+    "li_idx = 0\n",
+    "for i, site in enumerate(first_structure.sites):\n",
+    "    elem = site.species.elements[0].symbol\n",
+    "\n",
+    "    if elem == 'Li':\n",
+    "        occ_val = occ_structure.sites[li_idx].species.num_atoms\n",
+    "        all_species.append({elem: occ_val})\n",
+    "        all_labels.append(f'Li{li_idx + 1}')\n",
+    "        li_idx += 1\n",
+    "    else:\n",
+    "        all_species.append({elem: 1.0})\n",
+    "        all_labels.append(f'{elem}{i + 1}')\n",
+    "\n",
+    "    all_coords.append(site.frac_coords)\n",
+    "\n",
+    "input_structure = Structure(\n",
+    "    lattice=first_structure.lattice,\n",
+    "    species=all_species,\n",
+    "    coords=all_coords,\n",
+    "    labels=all_labels,\n",
+    ")\n",
+    "\n",
+    "print(f'Built input structure with {len(input_structure)} sites')\n",
+    "print(f'  Formula: {input_structure.composition.formula}')\n",
+    "\n",
+    "# Save to a CIF file (in temp dir, gitignored)\n",
+    "output_dir = Path(tempfile.gettempdir()) / 'gemdat_goac_demo'\n",
+    "output_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "cif_path = output_dir / 'li_in_cl_occupancy.cif'\n",
+    "input_structure.to(filename=str(cif_path))\n",
+    "print(f'  Saved to {cif_path}')\n",
+    "\n",
+    "# Show a few sample sites\n",
+    "print(f'\\nSample sites:')\n",
+    "for site in input_structure.sites[:6]:\n",
+    "    occ_info = site.species.reduced_formula\n",
+    "    print(f'  {site.label:8s}: {occ_info:10s}  at ({site.frac_coords[0]:.3f}, {site.frac_coords[1]:.3f}, {site.frac_coords[2]:.3f})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the GOAC Coulomb Problem\n",
+    "\n",
+    "Set charges (oxidation states) and supercell dimensions, then compute the Coulomb matrices. This is the setup step before sampling. More details can be found [here](https://iffgit.fz-juelich.de/k.koester/goac/-/blob/master/GOAC_Documentation.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calculating Coulomb matrices...\n",
+      "Started Coulomb matrices calculation\n",
+      "Finished Coulomb matrices calculations in: 0.0s\n",
+      "\n",
+      "-------- WARNING - Charged Supercell --------\n",
+      "Calculating correction for charged supercell\n",
+      "\n",
+      "Iterate sites (disordered): 17\n",
+      "Total combinations: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define charges for each element (oxidation states)\n",
+    "# Each dict value is (charge, tolerance) — GOAC uses these for Coulomb energy\n",
+    "charges = {\n",
+    "    'Li*': (1.0, 0.1),   # Li⁺\n",
+    "    'In*': (3.0, 0.1),   # In³⁺\n",
+    "    'Cl*': (-1.0, 0.1),  # Cl⁻\n",
+    "}\n",
+    "\n",
+    "# Use a supercell to create inequivalent Li environments\n",
+    "# This makes different Li arrangements have distinct Coulomb energies\n",
+    "supercell = [2, 1, 1]\n",
+    "\n",
+    "# Create the GOAC iteration problem\n",
+    "problem = Iteration_Problem(\n",
+    "    cif_file=str(cif_path),\n",
+    "    fixed_sites=[],\n",
+    "    charges=charges,\n",
+    "    supercell=supercell,\n",
+    ")\n",
+    "\n",
+    "print('Calculating Coulomb matrices...')\n",
+    "problem.calc_coulomb_matrices()\n",
+    "\n",
+    "print(f'Iterate sites (disordered): {len(problem.iterate_sites)}')\n",
+    "print(f'Total combinations: {problem.total_combinations:.0f}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run GOAC Random Sampling\n",
+    "\n",
+    "We use the `Random_Solver` in `Random` mode — it generates many random configurations and reports their energies. This gives us a histogram of the energy landscape, showing how different Li arrangements affect the Coulomb energy. The solver keeps the best configuration for visualization.\n",
+    "\n",
+    "Optionally, the solver can be switched to `Random-MC` (Monte Carlo), `Random-SA` (Simulated Annealing), or `Random-GA` (Genetic Algorithm) for more targeted optimization — see the [GOAC documentation](https://iffgit.fz-juelich.de/k.koester/goac/-/blob/master/GOAC_Documentation.pdf)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating solver of type: Random\n",
+      "Generating 200 random configurations...\n",
+      "Solver finished in 0.0s\n",
+      "✓ Random sampling complete!\n",
+      "  Configurations evaluated: 200\n",
+      "  Best energy:  -1189.80 eV\n",
+      "  Mean energy:  -1176.68 eV\n",
+      "  Std energy:   8.49 eV\n",
+      "  Energy range: 43.87 eV\n",
+      "\n",
+      "✓ Best configuration: Li35 In16 Cl96\n",
+      "  Atoms: 147\n",
+      "\n",
+      "Energy statistics:\n",
+      "  min  = -1189.80 eV\n",
+      "  max  = -1145.93 eV\n",
+      "  mean = -1176.68 eV\n",
+      "  std  = 8.49 eV\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_30448/2989888074.py:43: UserWarning: The default value of primitive was changed from True to False in https://github.com/materialsproject/pymatgen/pull/3419. CifParser now returns the cell in the CIF file as is. If you want the primitive cell, please set primitive=True explicitly.\n",
+      "  best_structure = parser.parse_structures()[0]\n",
+      "/tmp/ipykernel_30448/2989888074.py:43: UserWarning: Issues encountered while parsing CIF: 2 fractional coordinates rounded to ideal values to avoid issues with finite precision.\n",
+      "  best_structure = parser.parse_structures()[0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use the Random_Solver in 'Random' mode to generate many configurations\n",
+    "# This gives us a distribution of energies rather than just one structure\n",
+    "n_samples = 200  # Number of random configurations (fast, nice histogram)\n",
+    "\n",
+    "solver = Random_Solver(name='Random', problem=problem, n=n_samples, w=n_samples)\n",
+    "solver.initialize()\n",
+    "\n",
+    "# Set tolerance to -1 so GOAC doesn't deduplicate solutions with similar energies\n",
+    "solver.opt['tol'] = -1\n",
+    "\n",
+    "print(f'Generating {n_samples} random configurations...')\n",
+    "out_name = str(output_dir / 'li_in_cl_optimized')\n",
+    "solver.solve(out_name)\n",
+    "print('✓ Random sampling complete!')\n",
+    "\n",
+    "# Read the summary file to get all energies\n",
+    "energies = []\n",
+    "summary_file = output_dir / 'li_in_cl_optimized-summary.txt'\n",
+    "if summary_file.exists():\n",
+    "    with open(summary_file, 'r') as f:\n",
+    "        lines = f.readlines()[1:]  # Skip header\n",
+    "        for line in lines:\n",
+    "            parts = line.strip().split()\n",
+    "            if len(parts) >= 2 and parts[0] != 'NaN':\n",
+    "                try:\n",
+    "                    energies.append(float(parts[1]))\n",
+    "                except ValueError:\n",
+    "                    pass\n",
+    "\n",
+    "if energies:\n",
+    "    print(f'  Configurations evaluated: {len(energies)}')\n",
+    "    print(f'  Best energy:  {min(energies):.2f} eV')\n",
+    "    print(f'  Mean energy:  {np.mean(energies):.2f} eV')\n",
+    "    print(f'  Std energy:   {np.std(energies):.2f} eV')\n",
+    "    print(f'  Energy range: {max(energies) - min(energies):.2f} eV')\n",
+    "\n",
+    "# Load the best optimized structure\n",
+    "from pymatgen.io.cif import CifParser\n",
+    "\n",
+    "best_cif = output_dir / 'li_in_cl_optimized-0.cif'\n",
+    "if best_cif.exists():\n",
+    "    parser = CifParser(str(best_cif))\n",
+    "    best_structure = parser.parse_structures()[0]\n",
+    "    print(f'\\n✓ Best configuration: {best_structure.composition.formula}')\n",
+    "    print(f'  Atoms: {len(best_structure)}')\n",
+    "else:\n",
+    "    print(f'\\n✗ Best structure file not found')\n",
+    "\n",
+    "# Show a quick inline summary of the energy statistics\n",
+    "if energies:\n",
+    "    print(f'\\nEnergy statistics:')\n",
+    "    print(f'  min  = {min(energies):.2f} eV')\n",
+    "    print(f'  max  = {max(energies):.2f} eV')\n",
+    "    print(f'  mean = {np.mean(energies):.2f} eV')\n",
+    "    print(f'  std  = {np.std(energies):.2f} eV')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize Results\n",
+    "\n",
+    "Three views of the GOAC results: energy landscape over the 2×1×1 supercell, the best optimized structure, and a combined occupancy-to-configuration overlay."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAu65JREFUeJzs3XdYFFfbBvB7l947glTFgqLYNdgLCFaMvUVQY0WMGt+osRtjjcaYKGpUwEJiNPYuEbEbFJXYS0AFQawsSGfn+4OPjesC0pdy/65rL9wzZ848M4zD7jPnnBEJgiCAiIiIiIiIiIioDImVHQAREREREREREVU9TEoREREREREREVGZY1KKiIiIiIiIiIjKHJNSRERERERERERU5piUIiIiIiIiIiKiMsekFBERERERERERlTkmpYiIiIiIiIiIqMwxKUVERERERERERGWOSSkiIiIiIiIiIipzTEoRVQJRUVEQiUQICAgo9W0FBARAJBIhKipKVmZvb4+ePXuW+rYB4MyZMxCJRDhz5kyZbO9jUqkUDRo0wPfff6+U7VP55u3tDXt7e7kykUiEBQsWyN5v2LABtra2SEtLK9vgiIiIiIjKGSalqFzKSXzk9bp8+bKyQyxVH+6rqqoqjI2N0axZM3z11Ve4c+dOiW1n/fr1ZZLIKoryGttvv/2GZ8+eYdKkSbKysLAwTJo0CU5OTtDR0YGtrS0GDhyIBw8elNh2T548idGjR6NBgwZQUVFRSHwUV1JSEubPnw8PDw8YGxuXWZKzKvL29kZ6ejo2btyo7FCIiIiIiJRKVdkBEOVn0aJFqFGjhkJ5rVq1lBBN2XJzc8OIESMgCAISEhJw8+ZNBAYGYv369Vi+fDmmTZsmq2tnZ4eUlBSoqakVahvr16+HqakpvL29C7zOF198gcGDB0NDQ6NQ2yqsvGJr3749UlJSoK6uXqrbz8vKlSsxePBgGBgYyMqWL1+OCxcuYMCAAXB2dkZcXBx++eUXNG3aFJcvX0aDBg2Kvd2goCDs2rULTZs2RfXq1Yvd3sdevXqFRYsWwdbWFo0aNVJaT7SqQFNTE15eXli9ejV8fX0hEomUHRIRERERkVIwKUXlWrdu3dC8eXNlh4H3799DR0enTLdZp04dDB8+XK5s2bJl6NWrF77++ms4Ojqie/fuALJ7VmlqapZqPDnHQEVFBSoqKqW6rfyIxeJS39e8XL9+HTdv3sSqVavkyqdNm4agoCC5RNmgQYPQsGFDLFu2DDt27JCrf/LkSTg6OsLW1lZhG0lJSTh06BCGDBkiV75kyRL8+uuvUFNTQ8+ePXHr1q0840xLS8Mff/yBL774Itflhw4dQsuWLVGtWjVZmaWlJWJjY2FhYYGrV6+iRYsWeR+ISkIZ/69zDBw4ECtWrEBISAg6d+6slBiIiIiIiJSNw/eoQsuZS+mHH37Apk2b4ODgAA0NDbRo0QJhYWEK9e/du4f+/fvD2NgYmpqaaN68OQ4ePChXJ2foYGhoKCZOnAhzc3NYW1vLlq9btw41a9aElpYWWrZsiXPnzqFjx47o2LEjgOykgo6ODr766iuF7UdHR0NFRQVLly4t0v6amJjg999/h6qqqtycRrnNKRUXF4eRI0fC2toaGhoasLS0hKenp2wuKHt7e9y+fRuhoaGyoYI5+5DfMchtTqkcJ0+eROPGjaGpqYn69etj7969cssXLFiQa6+Qj9vML7a85pTavXs3mjVrBi0tLZiammL48OGIiYmRq+Pt7Q1dXV3ExMSgT58+0NXVhZmZGaZPn46srKxPHH1g//79UFdXR/v27eXKW7durdBzq3bt2nBycsLdu3flyqVSKXx9fdG1a1e8fPlSbll6ejo+//xzjBkzRmFZ9erVC9wTbs+ePRgxYgTWrl2rsOzEiRPo16+fQmJNQ0MDFhYWBWo/N5863wDFuZVy2Nvby/WIyzkfzp49i3HjxsHExAT6+voYMWIE3r59q7D+sWPH0K5dO+jo6EBPTw89evTA7du35erk/O4fP36M7t27Q09PD8OGDQOQ/Tv56aef0LBhQ2hqasLMzAweHh64evWqXBs7duyQnWPGxsYYPHgwnj17VqTj1axZMxgbG+PAgQNFWp+IiIiIqDJgTykq1xISEvDq1Su5MpFIBBMTE7myoKAgJCYmYty4cRCJRFixYgX69u2Lf//9V/ZF/vbt22jTpg2srKwwc+ZM6Ojo4I8//kCfPn3w559/4vPPP5drc+LEiTAzM8O8efPw/v17AICfnx8mTZqEdu3aYerUqYiKikKfPn1gZGQkS9ro6uri888/x65du7B69Wq5XkW//fYbBEGQfRkuCltbW3To0AEhISGQSCTQ19fPtV6/fv1w+/Zt+Pr6wt7eHvHx8Th16hSePn0Ke3t7rFmzBr6+vtDV1cXs2bMBQK7nTF7HIC8PHz7EoEGDMH78eHh5ecHf3x8DBgzA8ePH4ebmVqh9LEhsHwoICMDIkSPRokULLF26FC9evMBPP/2ECxcu4Pr16zA0NJTVzcrKgru7O1q1aoUffvgBwcHBWLVqFRwcHDBhwoR847p48SIaNGhQoOSQIAh48eIFnJyc5MrFYjH279+Pdu3awd3dHWfOnIG+vj6ysrIwdOhQhIaG4sCBAzAzM/vkNvIybNgwXLx4EVOmTIGhoSFGjBghi79v375o164dvvvuuyK3n5tPnW9FMWnSJBgaGmLBggW4f/8+/Pz88OTJE1liEgC2b98OLy8vuLu7Y/ny5UhOToafnx/atm2L69evy207MzMT7u7uaNu2LX744Qdoa2sDAEaPHo2AgAB069YNX375JTIzM3Hu3DlcvnxZ1lPz+++/x9y5czFw4EB8+eWXePnyJX7++We0b99e4RwrqKZNm+LChQtFOjZERERERJWCQFQO+fv7CwByfWloaMjqRUZGCgAEExMT4c2bN7LyAwcOCACEQ4cOycq6dOkiNGzYUEhNTZWVSaVSoXXr1kLt2rUVtt22bVshMzNTVp6WliaYmJgILVq0EDIyMmTlAQEBAgChQ4cOsrITJ04IAIRjx47J7Zezs7NcvbwAEHx8fPJc/tVXXwkAhJs3b8odB39/f0EQBOHt27cCAGHlypX5bsfJySnXePI6Bh8ui4yMlJXZ2dkJAIQ///xTVpaQkCBYWloKTZo0kZXNnz9fyO2yk1ubecUWEhIiABBCQkIEQRCE9PR0wdzcXGjQoIGQkpIiq3f48GEBgDBv3jxZmZeXlwBAWLRokVybTZo0EZo1a6awrY9ZW1sL/fr1+2Q9QRCE7du3CwCELVu25Lr877//FnR1dYX27dsLycnJwpdffimIRCIhKCjok2336NFDsLOzy7dOVlaWMGTIEEFVVVU4cOCAEBERIRgZGQktWrQQEhMT8103LCxM7nz6lIKebwCE+fPnK5Tb2dkJXl5esvc550OzZs2E9PR0WfmKFSsEAMKBAwcEQRCExMREwdDQUBgzZoxce3FxcYKBgYFcec7vfubMmXJ1T58+LQAQJk+erBCXVCoVBEEQoqKiBBUVFeH777+XW/7PP/8IqqqqcuVeXl4Kv5u89nvs2LGClpaWQjkRERERUVXB4XtUrq1btw6nTp2Sex07dkyh3qBBg2BkZCR7365dOwDAv//+CwB48+YNTp8+jYEDByIxMRGvXr3Cq1ev8Pr1a7i7u+Phw4cKQ73GjBkj18vp6tWreP36NcaMGQNV1f86GQ4bNkxu2wDg6uqK6tWrY+fOnbKyW7duISIiQmGeqKLQ1dUFACQmJua6XEtLC+rq6jhz5kyuw50K6uNjkJ/q1avL9TbLGW51/fp1xMXFFTmGT7l69Sri4+MxceJEubmmevToAUdHRxw5ckRhnfHjx8u9b9eunexcyc/r168Vfte5uXfvHnx8fODi4gIvL69c67Ro0QL79+/HlStX4OjoiM2bN+Pnn39WmEuqqMRiMQIDA+Hm5oZBgwbB1dUVFhYWOHbsmOz8KSkldb59bOzYsXK90iZMmABVVVUcPXoUAHDq1Cm8e/cOQ4YMkf2ffvXqFVRUVNCqVSuEhIQotPlxb7g///wTIpEI8+fPV6ib0xtr7969kEqlGDhwoNx2LCwsULt27Vy3UxBGRkZISUlBcnJykdYnIiIiIqroOHyPyrWWLVsWaKLzjyeMzkkc5HxBfvToEQRBwNy5czF37txc24iPj4eVlZXs/cdP/Xvy5AkAxSf/qaqqKgxPEovFGDZsGPz8/JCcnAxtbW3s3LkTmpqaGDBgwCf351OSkpIAAHp6erku19DQwPLly/H111+jWrVq+Oyzz9CzZ0+MGDGiUPMG5fbkw7zUqlVLYb6oOnXqAMie86o48xXlJ+f3UrduXYVljo6OOH/+vFxZzpxBHzIyMipwMkUQhHyXx8XFoUePHjAwMMCePXvyTep16dIFgwYNwrZt29CkSZNPDh8sLDU1Nfz000+oV68e4uPjsWHDBoWhryWhpM63j9WuXVvuva6uLiwtLWXzVD18+BAA8pwo/OOhraqqqnLzwwHA48ePUb16dRgbG+cZx8OHDyEIgkI8OQr71MscOecSn75HRERERFUVk1JUKeT1xT/nS59UKgUATJ8+He7u7rnW/TjZpKWlVayYRowYgZUrV2L//v0YMmQIgoKC0LNnTxgYGBSrXSC715WKikq+SaMpU6agV69e2L9/P06cOIG5c+di6dKlOH36NJo0aVKg7RT3GHwsry/fBZlkvKQU58mBJiYm+SavEhIS0K1bN7x79w7nzp1D9erV823Pz88P27Ztg5ubG4KDg+Hj4wM/P78ix/ex169fo0+fPjA1NYWFhQXGjBmDunXron79+iW2jRzFOd+K+vvP+X+9ffv2XJNfH/ZoBLKTZ2Jx4TsIS6VSiEQiHDt2LNfzp6g9z96+fQttbe0S/39GRERERFRRMClFVULNmjUBZPdocHV1LVIbdnZ2ALJ7XXXq1ElWnpmZiaioKDg7O8vVb9CgAZo0aYKdO3fC2toaT58+xc8//1zEPfjP06dPERoaChcXlzx7SuVwcHDA119/ja+//hoPHz5E48aNsWrVKuzYsQNAyfbQyOmN9mGbDx48AABZT7KcHmzv3r2Tmxg6p7fThwoaW87v5f79+wo9Zu7fvy9bXhIcHR0RGRmZ67LU1FT06tULDx48QHBw8CcTP7///jsmTZqE0aNHY/Pmzfjpp58wZcoUGBkZYcmSJcWONSkpCd27d8fz588RGhoKS0tLtG3bFm5ubrhw4UKRJx/Pz6fONyMjI7x7905unfT0dMTGxuba3sOHD+X+ryUlJSE2Nhbdu3eXbQ8AzM3Ni/z/2sHBASdOnMCbN2/y7C3l4OAAQRBQo0YNWe+/khAZGYl69eqVWHtERERERBUN55SiKsHc3BwdO3bExo0bc/0C/PLly0+20bx5c5iYmODXX39FZmamrHznzp159p754osvcPLkSaxZswYmJibo1q1b0XcC2XNjDRkyBFlZWbKn0uUmOTkZqampcmUODg7Q09NDWlqarExHR0chSVBUz58/x759+2TvJRIJtm3bhsaNG8t6seQkEc6ePSur9/79ewQGBiq0V9DYmjdvDnNzc2zYsEFu344dO4a7d++iR48eRd0lBS4uLrh165bcdoDsnj6DBg3CpUuXsHv3bri4uOTbztGjRzFixAj07dsXGzduBAB89dVXmDdvHpYuXYpVq1YVK860tDR4enri9u3bOHr0KJydnWFmZoZTp05BRUUFbm5uJTrPV0HPNwcHB7nfPQBs2rQpz55SmzZtQkZGhuy9n58fMjMzZf+P3N3doa+vjyVLlsjVy1GQ/9f9+vWDIAhYuHChwrKcnpZ9+/aFiooKFi5cqDB8UxAEvH79+pPbyU14eDhat25dpHWJiIiIiCoD9pSicu3YsWO4d++eQnnr1q1lvZ8Kat26dWjbti0aNmyIMWPGoGbNmnjx4gUuXbqE6Oho3Lx5M9/11dXVsWDBAvj6+qJz584YOHAgoqKiEBAQAAcHh1x79gwdOhTffPMN9u3bhwkTJhRq7pkHDx5gx44dEAQBEokEN2/exO7du5GUlITVq1fDw8Mj33W7dOmCgQMHon79+lBVVcW+ffvw4sULDB48WFavWbNm8PPzw+LFi1GrVi2Ym5vnOT/Pp9SpUwejR49GWFgYqlWrhq1bt+LFixfw9/eX1enatStsbW0xevRo/O9//4OKigq2bt0KMzMzPH36VK69gsampqaG5cuXY+TIkejQoQOGDBmCFy9e4KeffoK9vT2mTp1apP3JjaenJ7777juEhoaia9eusvKvv/4aBw8eRK9evfDmzRtZz6AcH05uL5VKMXXqVHTq1Ak7d+6UGw62cOFCvH37FvPnz8eIESPk5r6KiIjAwYMHAWT3SktISMDixYsBAI0aNUKvXr1kdffs2YPz58/j0KFDcgkyW1tbnDx5Eu3atcPq1auxYsUKuTh/+eUXvHv3Ds+fPwcAHDp0CNHR0QAAX1/fPIeeFvR8+/LLLzF+/Hj069cPbm5uuHnzJk6cOAFTU9Nc201PT5e1e//+faxfvx5t27ZF7969AWTPGeXn54cvvvgCTZs2xeDBg2Xn0pEjR9CmTRv88ssvubado1OnTvjiiy+wdu1aPHz4EB4eHpBKpTh37hw6deqESZMmwcHBAYsXL8asWbMQFRWFPn36QE9PD5GRkdi3bx/Gjh2L6dOn57udj127dg1v3ryBp6dnodYjIiIiIqpUlPPQP6L85TwSPq9XzqPqIyMj83wUPXJ5DPvjx4+FESNGCBYWFoKamppgZWUl9OzZU9izZ4/CtsPCwnKNbe3atYKdnZ2goaEhtGzZUrhw4YLQrFkzwcPDI9f63bt3FwAIFy9eLPD+f7ivYrFYMDQ0FJo0aSJ89dVXwu3btxXq5xyHnOPy6tUrwcfHR3B0dBR0dHQEAwMDoVWrVsIff/wht15cXJzQo0cPQU9PTwAgdOjQ4ZPHIGdZZGSkrMzOzk7o0aOHcOLECcHZ2VnQ0NAQHB0dhd27dyusf+3aNaFVq1aCurq6YGtrK6xevTrXNvOKLSQkRAAghISEyLW7a9cuoUmTJoKGhoZgbGwsDBs2TIiOjpar4+XlJejo6CjENH/+fKGgl0NnZ2dh9OjRcmUdOnTI93z92IMHD4T379/n2r5UKhVu3rypUJ7f/wkvLy+F+tevX89zH+7cuSOkpqYqlNvZ2eW5jQ9/Nx8r6PmWlZUlzJgxQzA1NRW0tbUFd3d34dGjR4KdnZ3cPuTsa2hoqDB27FjByMhI0NXVFYYNGya8fv1aYfshISGCu7u7YGBgIGhqagoODg6Ct7e3cPXqVVmdvH73giAImZmZwsqVKwVHR0dBXV1dMDMzE7p16yZcu3ZNrt6ff/4ptG3bVtDR0RF0dHQER0dHwcfHR7h//77cduzs7OTWy+1aNGPGDMHW1laQSqV5HlciIiIiospOJAifeJQUEeVLKpXCzMwMffv2xa+//qqw/PPPP8c///yDR48eKSE6Kmnbt2+Hj48Pnj59KjcvFpWcgIAAjBw5EmFhYQV6+mZFk5aWBnt7e8ycORNfffWVssMhIiIiIlIazilFVAipqakKc8ps27YNb968QceOHRXqx8bG4siRI/jiiy/KKEIqbcOGDYOtrS3WrVun7FCogvL394eamhrGjx+v7FCIiIiIiJSKc0oRFcLly5cxdepUDBgwACYmJggPD8eWLVvQoEEDDBgwQFYvMjISFy5cwObNm6GmpoZx48YpMWoqSWKxGLdu3VJ2GFSBjR8/ngkpIiIiIiIwKUVUKPb29rCxscHatWtlj5AfMWIEli1bBnV1dVm90NBQjBw5Era2tggMDJQ9fY6IiIiIiIiIsnFOKSIiIiIiIiIiKnOcU4qIiIiIiIiIiMock1JERERERERERFTmmJQiolIXFRUFkUiEgIAAZYeidC9evED//v1hYmICkUiENWvW4MyZMxCJRDhz5oyywysy/o6JiIiIiKiwmJQiKkFhYWGYNGkSnJycoKOjA1tbWwwcOBAPHjzItf7du3fh4eEBXV1dGBsb44svvsDLly8V6kmlUqxYsQI1atSApqYmnJ2d8dtvv5X27lApmDp1Kk6cOIFZs2Zh+/bt8PDwUHZIhRIUFIQ1a9YoOwwiIiIiIqoEONE5UQnq378/Lly4gAEDBsDZ2RlxcXH45ZdfkJSUhMuXL6NBgwayutHR0WjSpAkMDAwwefJkJCUl4YcffoCtrS3+/vtvuaf5zZo1C8uWLcOYMWPQokULHDhwAEeOHMFvv/2GwYMHK2NXCyUqKgo1atSAv78/vL29lR2OUllYWMDV1RU7duyQlUmlUqSnp0NdXR1icfm+V9CzZ0/cunULUVFRcuWCICAtLQ1qampQUVFRTnBERERERFShlO9vP0QVzLRp0/DkyROsXbsWX375JebMmYNz584hMzMTy5Ytk6u7ZMkSvH//HqdPn8bkyZPx7bff4o8//sDNmzflhkDFxMRg1apV8PHxwaZNmzBmzBgcOnQI7dq1w//+9z9kZWUVOs73798Xd1epiOLj42FoaChXJhaLoampqZSEVHJycom0IxKJoKmpyYQUEREVSmkM/+7YsSM6duxYYu0VR0BAAEQikcLNHCobK1euRM2aNaGiooLGjRsDAOzt7Sv8TdLydI4TFReTUkQlqHXr1nI9nACgdu3acHJywt27d+XK//zzT/Ts2RO2trayMldXV9SpUwd//PGHrOzAgQPIyMjAxIkTZWUikQgTJkxAdHQ0Ll26lG9M3t7e0NXVxePHj9G9e3fo6elh2LBhAIBz585hwIABsLW1hYaGBmxsbDB16lSkpKTk2kZMTAz69OkDXV1dmJmZYfr06QpJsXfv3sHb2xsGBgYwNDSEl5cX3r17l2tsp0+fRrt27aCjowNDQ0N4enoqHKcFCxZAJBLhwYMHGD58OAwMDGBmZoa5c+dCEAQ8e/YMnp6e0NfXh4WFBVatWpXv8fjQjh070LJlS2hra8PIyAjt27fHyZMn5eqsX78eTk5O0NDQQPXq1eHj46OwPx07dkSDBg1w584ddOrUCdra2rCyssKKFStkdXI+lAqCgHXr1kEkEkEkEgFAnnNKrVu3DjVr1oSWlhZatmyJc+fOKXwIyevDbm5t5sR57do1tG/fHtra2vj2228BZJ9nPXr0QPXq1aGhoQEHBwd89913cr/fjh074siRI3jy5Iksfnt7ewB5f6kozO/40aNH8Pb2hqGhIQwMDDBy5EiFpNmpU6fQtm1bGBoaQldXF3Xr1pXtAxERlS85f6OuXr1aIu1FRUVh5MiRcHBwgKamJiwsLNC+fXvMnz8/3/WeP3+OBQsW4MaNGyUSh7Ll/A3Oeeno6KB+/fpYvHhxid1syk1RhvBnZWXB398fHTt2hLGxMTQ0NGBvb4+RI0eW2HmRl5MnT+Kbb75BmzZt4O/vjyVLlpTq9kranTt3sGDBAiY0qdJTVXYARJWdIAh48eIFnJycZGUxMTGIj49H8+bNFeq3bNkSR48elb2/fv06dHR0UK9ePYV6Ocvbtm2bbwyZmZlwd3dH27Zt8cMPP0BbWxsAsHv3biQnJ2PChAkwMTHB33//jZ9//hnR0dHYvXu3XBtZWVlwd3dHq1at8MMPPyA4OBirVq2Cg4MDJkyYINtXT09PnD9/HuPHj0e9evWwb98+eHl5KcQUHByMbt26oWbNmliwYAFSUlLw888/o02bNggPD5clO3IMGjQI9erVw7Jly3DkyBEsXrwYxsbG2LhxIzp37ozly5dj586dmD59Olq0aIH27dvne0wWLlyIBQsWoHXr1li0aBHU1dVx5coVnD59Gl27dgWQnSxZuHAhXF1dMWHCBNy/fx9+fn4ICwvDhQsXoKamJmvv7du38PDwQN++fTFw4EDs2bMHM2bMQMOGDdGtWze0b98e27dvxxdffAE3NzeMGDEi3/j8/PwwadIktGvXDlOnTkVUVBT69OkDIyMjWFtb57tufl6/fo1u3bph8ODBGD58OKpVqwYg+4uDrq4upk2bBl1dXZw+fRrz5s2DRCLBypUrAQCzZ89GQkICoqOj8eOPPwIAdHV189xWYX/HAwcORI0aNbB06VKEh4dj8+bNMDc3x/LlywEAt2/fRs+ePeHs7IxFixZBQ0MDjx49woULF4p8PIiISLns7OyQkpIi9zc1N48ePUKLFi2gpaWFUaNGwd7eHrGxsQgPD8fy5cuxcOFCWd2PbzA9f/4cCxcuhL29vay3TFn54osvMHjwYGhoaJRoux9+lkhKSsK5c+cwd+5c3Lx5U+EzXEkJCgrCrVu3MGXKlALVT0lJQd++fXH8+HG0b98e3377LYyNjREVFYU//vgDgYGBePr0abE+1+Tn9OnTEIvF2LJli9xN4/v375f76RKA7KTUwoUL0bFjR4XPTB+f40QVmkBEpWr79u0CAGHLli2ysrCwMAGAsG3bNoX6//vf/wQAQmpqqiAIgtCjRw+hZs2aCvXev38vABBmzpyZ7/a9vLzyrJecnKxQtnTpUkEkEglPnjxRaGPRokVydZs0aSI0a9ZM9n7//v0CAGHFihWysszMTKFdu3YCAMHf319W3rhxY8Hc3Fx4/fq1rOzmzZuCWCwWRowYISubP3++AEAYO3asXJvW1taCSCQSli1bJit/+/atoKWlJXh5eeV7TB4+fCiIxWLh888/F7KysuSWSaVSQRAEIT4+XlBXVxe6du0qV+eXX34RAAhbt26VlXXo0EHh95mWliZYWFgI/fr1k2sfgODj4yNXFhISIgAQQkJCZOuamJgILVq0EDIyMmT1AgICBABChw4dZGX+/v4CACEyMjLfNj+Mc8OGDQrHJLdzYdy4cYK2trbsXBSE7PPRzs5OoW5kZGSxf8ejRo2Sa/Pzzz8XTExMZO9//PFHAYDw8uVLhe0TEVH5k/M3KiwsrNhtTZw4UVBVVRWioqIUlr148SLfdXM+d334N6oiy+2zhCAIQv/+/QWxWCykpKSUynbz+gyQFx8fHwGA8OOPPyosy8zMFFauXCk8e/as5AL8yMiRIwUdHZ1Sa7+wkpKSClV/9+7dCp/liCqj8p8iJqrA7t27Bx8fH7i4uMj1FsoZHpfbXTNNTU25OikpKQWq9yk5vZk+pKWlJfv3+/fv8erVK7Ru3RqCIOD69esK9cePHy/3vl27dvj3339l748ePQpVVVW5bamoqMDX11duvdjYWNy4cQPe3t4wNjaWlTs7O8PNzU2up1iOL7/8Uq7N5s2bQxAEjB49WlZuaGiIunXrysWUm/3790MqlWLevHkKd8pyhtQFBwcjPT0dU6ZMkaszZswY6Ovr48iRI3Lr6erqYvjw4bL36urqaNmy5Sdjyc3Vq1fx+vVrjBkzBqqq/3VoHTZsGIyMjArd3oc0NDQwcuRIhfIPz4XExES8evUK7dq1Q3JyMu7du1fo7RTld5zb+fX69WtIJBIAkM3FdeDAAUil0kLHRERE5U9B55R6/PgxrK2tYWdnp7DM3Nxc7v2HQ93PnDmDFi1aAABGjhwpG/L24fauXLkCDw8PGBgYQFtbGx06dFDohZuYmIgpU6bA3t4eGhoaMDc3h5ubG8LDw/ONO7dh9vb29ujZsyfOnz+Pli1bQlNTEzVr1sS2bdvybetTLCwsIBKJ5D47lNT+5TeEPzfR0dHYuHEj3Nzccu1ZpaKigunTp8v1krp+/Tq6desGfX196OrqokuXLrh8+bLcejnH88KFC5g2bRrMzMygo6ODzz//XO4J1iKRCP7+/nj//r3C7zy3OaUiIiLQoUMHaGlpwdraGosXL4a/v7/C704kEmHBggUK+/NxmzlxhoaGYuLEiTA3N5ft65MnTzBx4kTUrVsXWlpaMDExwYABA+S2ExAQgAEDBgAAOnXqJNuHnGkZcptTKj4+HqNHj0a1atWgqamJRo0aITAwUK5Ozv+3H374AZs2bYKDgwM0NDTQokULhIWFKewXUVng8D2iUhIXF4cePXrAwMAAe/bskZsAOicBkJaWprBeamqqXB0tLa0C1cuPqqpqrl2jnz59innz5uHgwYN4+/at3LKEhAS595qamjAzM5MrMzIyklvvyZMnsLS0VBjSVbduXbn3T548ybUcAOrVq4cTJ07g/fv30NHRkZV/OPcWABgYGEBTUxOmpqYK5a9fv1Zo90OPHz+GWCxG/fr186yTV4zq6uqoWbOmbHkOa2trWUIrh5GRESIiIvKNJb9t16pVS65cVVU13w+ABWFlZaUw7xmQPTRuzpw5OH36tCwJlOPjc6EgSuJ3nJOAe/v2LfT19TFo0CBs3rwZX375JWbOnIkuXbqgb9++6N+/f4Xohk9EREVnZ2eH4OBgnD59Gp07dy7wevXq1cOiRYswb948jB07Fu3atQOQPQ8okD3Eq1u3bmjWrBnmz58PsVgMf39/dO7cGefOnZNNlzB+/Hjs2bMHkyZNQv369fH69WucP38ed+/eRdOmTQu9P48ePUL//v0xevRoeHl5YevWrfD29kazZs3kpnzIS2pqKl69egUg+8bihQsXEBgYiKFDh8olpUpq/wo7hP/YsWPIzMzEF198UaDjcfv2bbRr1w76+vr45ptvoKamho0bN6Jjx44IDQ1Fq1at5Or7+vrCyMgI8+fPR1RUFNasWYNJkyZh165dAIDt27dj06ZN+Pvvv7F582YA//3OPxYTEyNL/MyaNQs6OjrYvHlziQy5nDhxIszMzDBv3jzZg4bCwsJw8eJFDB48GNbW1oiKioKfnx86duyIO3fuQFtbG+3bt8fkyZOxdu1afPvtt7JpPD6eziNHSkoKOnbsiEePHmHSpEmoUaMGdu/eDW9vb7x79w5fffWVXP2goCAkJiZi3LhxEIlEWLFiBfr27Yt///33k0NpiUoak1JEpSAhIQHdunXDu3fvcO7cOVSvXl1uuaWlJYDs3iQfi42NlU0EmVM3JCQEgiDIJT1y1v247dxoaGgofGnPysqCm5sb3rx5gxkzZsDR0RE6OjqIiYmBt7e3Qk8UZT9VLbft5xWTIAilHY4CZcXycSIsR15PZcwtifnu3Tt06NAB+vr6WLRokWwC2fDwcMyYMaPMeiV96hhqaWnh7NmzCAkJwZEjR3D8+HHs2rULnTt3xsmTJ5V+jhIRUemZPHkytm/fji5duqBx48bo0KEDOnXqBDc3N9lcmbmpVq0aunXrhnnz5sHFxUWuV7MgCBg/fjw6deqEY8eOyf6mjhs3Dk5OTpgzZ45s7p4jR45gzJgxcg9U+eabb4q8P/fv38fZs2dlSbKBAwfCxsYG/v7++OGHHz65/pYtW7Blyxa5sj59+uDXX38tlf1zc3ODlZUV3r59K3cM85LzUJOGDRt+si4AzJkzBxkZGTh//jxq1qwJABgxYgTq1q2Lb775BqGhoXL1TUxMcPLkSdk+SaVSrF27FgkJCTAwMMDw4cMRHByM8PDwT8a7fPlyvH37FuHh4bI5x0aOHInatWsXKPb8GBsb46+//pL7jNKjRw/0799frl6vXr3g4uKCP//8E1988QVq1qyJdu3aYe3atXBzc/vkk/Y2bdqEu3fvYseOHbIHGo0fPx4dOnTAnDlzMGrUKOjp6cnqP336FA8fPpTdAKxbty48PT1x4sQJ9OzZs9j7TVQYvLVMVMJSU1PRq1cvPHjwAIcPH861N46VlRXMzMxyferI33//LTcJZ+PGjZGcnKzwxLIrV67IlhfFP//8gwcPHmDVqlWYMWMGPD094erqWqAkV17s7OwQGxuLpKQkufL79+8r1MutHMge8mhqairXg6akOTg4QCqV4s6dO3nWySvG9PR0REZG5jp8oKTktP3o0SO58szMTIUnsOR8mPj4iYAf9+TKz5kzZ/D69WsEBATgq6++Qs+ePeHq6prrUMG8kmAfK63fsVgsRpcuXbB69WrcuXMH33//PU6fPo2QkJBCt0VERBWHk5MTbty4geHDhyMqKgo//fQT+vTpg2rVqsklYgrjxo0bePjwIYYOHYrXr1/j1atXePXqFd6/f48uXbrg7NmzshszhoaGuHLlCp4/f14i+1O/fn1ZQgoAzMzMCjQFQQ5PT0+cOnUKp06dwoEDBzBr1iwcP34cQ4cOld3MUeb+5fS6/jARkpesrCycPHkSffr0kSWkgOwbs0OHDsX58+cVenGPHTtW7jNJu3btkJWVVajPPzmOHz8OFxcXuc/UxsbGsuROcYwZM0bhptmHNwgzMjLw+vVr1KpVC4aGhp8cDpqXo0ePwsLCAkOGDJGVqampYfLkyUhKSlJI6g0aNEjuc17OuViUaSeIiotJKaISlJWVhUGDBuHSpUvYvXs3XFxc8qzbr18/HD58GM+ePZOV/fXXX3jw4IFsDDmQ/aFDTU0N69evl5UJgoANGzbAysoqz67In5LzB/LDnjyCIOCnn34qUnsA0L17d2RmZsLPz09WlpWVhZ9//lmunqWlJRo3bozAwEC5ZMqtW7dw8uRJdO/evcgxFESfPn0gFouxaNEihV5AOcfD1dUV6urqWLt2rdwx2rJlCxISEtCjR49Si6958+YwMTHBr7/+iszMTFn5zp07FYZZOjg4AADOnj0rK8vKysKmTZsKvL3czoX09HS5cy6Hjo5OgYbzlcbv+M2bNwplOR8gcxviSkRElUudOnWwfft2vHr1ChEREViyZAlUVVUxduxYBAcHF7q9hw8fAgC8vLxgZmYm99q8eTPS0tJkf/NWrFiBW7duwcbGBi1btsSCBQuK9QX+4yHrgOK0CPmxtraGq6srXF1d0bt3byxZsgSLFy/G3r17cfjwYaXvn76+PoDsuao+5eXLl0hOTs5zyL9UKpX7vAzkP+S/sJ48eaIwZQKgOI1CUdSoUUOhLCUlBfPmzYONjQ00NDRgamoKMzMzvHv3rkhTJgDZ+1C7dm2FkRE5w/0+TtaV5PEjKi4O3yMqQV9//TUOHjyIXr164c2bN9ixY4fc8g+7D3/77bfYvXs3OnXqhK+++gpJSUlYuXIlGjZsKDcRtbW1NaZMmYKVK1ciIyMDLVq0wP79+3Hu3Dns3LmzyEOWHB0d4eDggOnTpyMmJgb6+vr4888/i/XHqFevXmjTpg1mzpyJqKgo1K9fH3v37s31D+zKlSvRrVs3uLi4YPTo0UhJScHPP/8MAwODXCeQLEm1atXC7Nmz8d1336Fdu3bo27cvNDQ0EBYWhurVq2Pp0qUwMzPDrFmzsHDhQnh4eKB37964f/8+1q9fjxYtWhSo63pRqaurY8GCBfD19UXnzp0xcOBAREVFISAgAA4ODnJ3Bp2cnPDZZ59h1qxZePPmDYyNjfH777/LJbM+pXXr1jAyMoKXlxcmT54MkUiE7du35zr0sFmzZti1axemTZuGFi1aQFdXF7169cq13ZL+HS9atAhnz55Fjx49YGdnh/j4eKxfvx7W1tZo27ZtodsjIqKKSUVFBQ0bNkTDhg3h4uKCTp06YefOnXB1dS1UOzk3plauXJlnz/OceZMGDhyIdu3aYd++fTh58iRWrlyJ5cuXY+/evejWrVuR9iE3xRn236VLFwDZN6p69eql1P1zdHQEkN0zv6i9+vNTnqZwAAo3bYKvry/8/f0xZcoUuLi4wMDAACKRCIMHDy43UyYQlSUmpYhK0I0bNwAAhw4dwqFDhxSWf5jIsLGxQWhoKKZNm4aZM2dCXV0dPXr0wKpVqxQmVly2bBmMjIywceNGBAQEoHbt2tixYweGDh1a5FjV1NRw6NAhTJ48GUuXLoWmpiY+//xzTJo0CY0aNSpSm2KxGAcPHsSUKVOwY8cOiEQi9O7dG6tWrUKTJk3k6rq6uuL48eOYP38+5s2bBzU1NXTo0AHLly/P9a5SSVu0aBFq1KiBn3/+GbNnz4a2tjacnZ3lJuRcsGABzMzM8Msvv2Dq1KkwNjbG2LFjsWTJklKfBHLSpEkQBAGrVq3C9OnT0ahRIxw8eBCTJ0+WPXkxx86dOzFu3DgsW7YMhoaGGD16tGyejYIwMTHB4cOH8fXXX2POnDkwMjLC8OHD0aVLF7i7u8vVnThxIm7cuAF/f3/8+OOPsLOzyzMpVdK/4969eyMqKgpbt27Fq1evYGpqig4dOmDhwoUwMDAodHtERFTxNW/eHEDu83TmyGvoeU5vY319/QIltCwtLTFx4kRMnDgR8fHxaNq0Kb7//vsiJW1KQ84NqZxpFEp6/wo6hB8AunXrBhUVFezYseOTk52bmZlBW1s7zyH/YrEYNjY2Bd52YdnZ2SlMmQAoTqMAZPco+njKhPT09HzPv4/t2bMHXl5ecvN3paamKrRbmONtZ2eHiIgISKVSud5SOU9QLs1pJ4iKTSAiogohKytLMDY2Fr788ktlh0JERPRJ/v7+AgAhLCwszzqRkZECAMHf3z/fts6ePSukp6crlO/atUsAIEyePFlW1qFDB6FDhw6y93fv3hUACD/++KPcullZWYKDg4NQu3ZtITExUaHt+Ph4QRAEITMzU3j37p3C8hYtWgjNmzfPN+6cYxAZGSkrs7OzE3r06KFQ9+O48wJA8PHxUSifN2+eAEDw8/MTBKHk92/QoEGCoaHhJ+PLMX78eAGAsHbtWoVlWVlZwg8//CA8e/ZMEARB6NOnj6ChoSF3nOLi4gR9fX2hffv2srK8zqmQkBABgBASEiIr8/LyEnR0dBS2bWdnJ3h5ecneT5o0SRCJRML169dlZa9fvxaMjY0VfnfNmzcXmjRpItfezz//LACQazO/c9/Y2Fjw9vaWK1uxYoVCG8eOHRMACPv27VNo4+NzZc2aNQIAISgoSFaWkZEhtGnTRtDV1RUkEokgCP/9f1u5cqVCmwCE+fPnK5QTlTb2lCIiKodSU1OhoaEhd5ds27ZtePPmzSefwEJERFSebN26FcePH1co//gx9flZvnw5rl27hr59+8LZ2RkAEB4ejm3btsHY2BhTpkzJc10HBwcYGhpiw4YN0NPTg46ODlq1aoUaNWpg8+bN6NatG5ycnDBy5EhYWVkhJiYGISEh0NfXx6FDh5CYmAhra2v0798fjRo1gq6uLoKDgxEWFibX26UsPXjwQDZNRHJyMi5fvozAwEDUqlVL1jNJLBaX6P4VZgg/AKxatQqPHz/G5MmTsXfvXvTs2RNGRkZ4+vQpdu/ejXv37mHw4MEAgMWLF+PUqVNo27YtJk6cCFVVVWzcuBFpaWlYsWJFKR7J7KcM7tixA25ubvD19YWOjg42b94MW1tbvHnzRu6z2Jdffonx48ejX79+cHNzw82bN3HixAmYmpoWeHs9e/bE9u3bYWBggPr16+PSpUsIDg6GiYmJXL3GjRtDRUUFy5cvR0JCAjQ0NNC5c2eYm5srtDl27Fhs3LgR3t7euHbtGuzt7bFnzx5cuHABa9asKdCE80RKo+ysGBERKQoJCREaN24sfP/998KGDRuEsWPHCioqKkKDBg2EtLQ0ZYdHRET0STm9RfJ6PXv2rMA9pS5cuCD4+PgIDRo0EAwMDAQ1NTXB1tZW8Pb2Fh4/fixXN7ceRwcOHBDq168vqKqqKmzv+vXrQt++fQUTExNBQ0NDsLOzEwYOHCj89ddfgiAIQlpamvC///1PaNSokaCnpyfo6OgIjRo1EtavX1/gY1DSPaU+fKmoqAjW1tbC2LFjhRcvXijUL6n9S0pKEoYOHSoYGhoKAAQ7O7tPxpqZmSls3rxZaNeunez3ZmdnJ4wcOVKuZ5IgCEJ4eLjg7u4u6OrqCtra2kKnTp2EixcvytUpjZ5SOceoXbt2goaGhmBtbS0sXbpUWLt2rQBAiIuLk9XLysoSZsyYIZiamgra2tqCu7u78OjRI4U28+sp9fbtW2HkyJGCqampoKurK7i7uwv37t3LNa5ff/1VqFmzpqCioiK3f7mdKy9evJC1q66uLjRs2FDh/xV7SlF5JBIEzmZGRFTeREVFYfLkyfj7779lE5h3794dy5Yty/UOGRERERGVnClTpmDjxo1ISkoq8oOFiOjTmJQiIiIiIiKiKislJUXuSXmvX79GnTp10LRpU5w6dUqJkRFVfpxTioiIiIiIiKosFxcXdOzYEfXq1cOLFy+wZcsWSCQSzJ07V9mhEVV6TEoRERERERFRldW9e3fs2bMHmzZtgkgkQtOmTbFlyxa0b99e2aERVXqVfvieVCrF8+fPoaenJ/fkBCIiIqLCEgQBiYmJqF69OsRisbLDISIiIqrQKn1PqefPn8PGxkbZYRAREVEl8uzZM1hbWys7DCIiIqIKTalJKT8/P/j5+SEqKgoA4OTkhHnz5qFbt24AgI4dOyI0NFRunXHjxmHDhg0F3oaenh6A7A+P+vr6JRP4hxwdgdhYwNISuHev5NsnIiKickMikcDGxkb2+YKIiIiIik6pSSlra2ssW7YMtWvXhiAICAwMhKenJ65fvw4nJycAwJgxY7Bo0SLZOtra2oXaRs6QPX19/dJJSuV03ReLgdJonyq/fdZASgygZQV8Hq3saIiIqAA4JQARVSYdO3YEAJw5c0apcRBR1aPUyRB69eqF7t27o3bt2qhTpw6+//576Orq4vLly7I62trasLCwkL1KJbFERERERERURm7fvo0BAwagZs2a0NbWhqmpKdq3b49Dhw4p1PX29oZIJFJ4OTo6FmhbIpEIkyZNKuldyNf69esREBBQptskooqp3MwplZWVhd27d+P9+/dwcXGRle/cuRM7duyAhYUFevXqhblz5xa6t1SpatoUsLEBzMyUHQlVVMZNgVQbQJPnEBEREVFV8OTJEyQmJsLLywvVq1dHcnIy/vzzT/Tu3RsbN27E2LFj5epraGhg8+bNcmUGBgYlFs/JkydLrC0gOyllamoKb2/vEm2XiCofpSel/vnnH7i4uCA1NRW6urrYt28f6tevDwAYOnQo7OzsUL16dURERGDGjBm4f/8+9u7dm2d7aWlpSEtLk72XSCSluwMHD5Zu+1T5deA5RERERFSVdO/eHd27d5crmzRpEpo1a4bVq1crJKVUVVUxfPjwUotHXV291NomIsqP0pNSdevWxY0bN5CQkIA9e/bAy8sLoaGhqF+/vtzFuGHDhrC0tESXLl3w+PFjODg45Nre0qVLsXDhwrIKn4iI/l9WVhYyMjKUHQZRsaipqUFFRUXZYRBRFaSiogIbGxuEhYXlujwrKwvv378vlelMCjqnlL+/P7Zv345bt24hISEBDg4O8PX1xYQJE2R17O3t8eTJEwD/zb/XoUMHWdv//vsvZsyYgb/++gupqalwdnbG3Llz0aNHD1kbZ86cQadOnbBr1y7cvXsXmzZtgkQigbu7O7Zs2QJNTU3MmDEDQUFBSE5OxoABA7BhwwZoaGjI2jh16hQWLlyIW7duITMzE1ZWVujXrx+WLFlSAkeMiEqK0pNS6urqqFWrFgCgWbNmCAsLw08//YSNGzcq1G3VqhUA4NGjR3kmpWbNmoVp06bJ3uc8JYeIiEqHIAiIi4vDu3fvlB0KUYkwNDSEhYUFJzMnolL3/v17pKSkICEhAQcPHsSxY8cwaNAghXrJycnQ19dHcnIyjIyMMGTIECxfvhy6urplGq+fnx+cnJzQu3dvqKqq4tChQ5g4cSKkUil8fHwAAGvWrIGvry90dXUxe/ZsAEC1atUAAC9evEDr1q2RnJyMyZMnw8TEBIGBgejduzf27NmDzz//XG57S5cuhZaWFmbOnIlHjx7h559/hpqaGsRiMd6+fYsFCxbg8uXLCAgIQI0aNTBv3jwA2XN29ezZE87Ozli0aBE0NDTw6NEjXLhwoQyPFhEVhNKTUh+TSqVyw+8+dOPGDQCApaVlnutraGjIZciJiKh05SSkzM3Noa2tzS/yVGEJgoDk5GTEx8cDyP/zBhFRSfj6669lN+PFYjH69u2LX375Ra6OpaUlvvnmGzRt2hRSqRTHjx/H+vXrcfPmTZw5cwaqqmX3lS40NBRaWlqy95MmTYKHhwdWr14tS0r16dMHc+bMgampqcKQw2XLluHFixc4d+4c2rZtCyD7aevOzs6YNm0aPD09IRb/9yyuzMxMhIaGQk1NDQDw8uVL/P777/Dw8MDRo0cBABMnTsSjR4+wdetWWVLq1KlTSE9Px7Fjx2Bqalp6B4SIik2pSalZs2ahW7dusLW1RWJiIoKCgnDmzBmcOHECjx8/RlBQELp37w4TExNERERg6tSpaN++PZydnZUZtrzevYGXL7MnOuf8UlQUV32B9LeAuhHQ/GdlR0NUKFlZWbKElImJibLDISq2nC9b8fHxMDc351A+IipVU6ZMQf/+/fH8+XP88ccfyMrKQnp6ulydpUuXyr0fPHgw6tSpg9mzZ2PPnj0YPHhwmcX7YUIqISEBGRkZ6NChA06cOIGEhIRPTr5+9OhRtGzZUpaQAgBdXV2MHTsWs2bNwp07d9CgQQPZshEjRsgSUkD2yJnffvsNo0aNkmu3VatWWLt2LTIzM6GqqgpDQ0MAwIEDBzBy5Ei5RBcRlS9K/d8ZHx+PESNGoG7duujSpQvCwsJw4sQJuLm5QV1dHcHBwejatSscHR3x9ddfo1+/frk+JlWpwsOBy5ezfxIVxbN9QNTO7J9EFUzOHFLl6qmoRMWUcz5zjjQiKm2Ojo5wdXXFiBEjcPjwYSQlJaFXr14QBCHf9aZOnQqxWIzg4OAyijTbhQsX4OrqCh0dHRgaGsLMzAzffvstgOwk1ac8efIEdevWVSivV6+ebPmHbG1t5d7nJL0+np7FwMAAUqlUFsOgQYPQpk0bfPnll6hWrRoGDx6MP/74A1KptIB7SkRlRak9pbZs2ZLnMhsbG4SGhpZhNEREVFQcskeVCc9nIlKW/v37Y9y4cXjw4EGuyZscWlpaMDExwZs3b8ostsePH6NLly5wdHTE6tWrYWNjA3V1dRw9ehQ//vhjqSR88uqtmld5TjJPS0sLZ8+eRUhICI4cOYLjx49j165d6Ny5M06ePMlesETlSLmbU4qoynE7BwhZgIh/HImIiIiqspSUFACf7nWUmJiIV69ewczMrCzCAgAcOnQIaWlpOHjwoFwPppCQEIW6eSX37ezscP/+fYXye/fuyZaXFLFYjC5duqBLly5YvXo1lixZgtmzZyMkJASurq4lth0iKh4mpahSePnyJSQSSaluQ19fv3T+8OvWKPk2iYiIiKjcypm37kMZGRnYtm0btLS0UL9+fQBAamoqMjIyoKenJ1f3u+++gyAI8PDwKLOYc3oXfTi0MCEhAf7+/gp1dXR0cn0qb/fu3bFmzRpcunQJLi4uALKfQLhp0ybY29vL9ru43rx5A2NjY7myxo0bA0CeD9UiIuVgUooqvJcvX2LEyC/xLjG5VLdjqKeNbf6by/SOFBGVHm9vbwQGBsreGxsbo0WLFlixYkWJPVBjwYIF2L9/v+zpscX1/fff48iRI7hx4wbU1dVz/cA/efJkXLhwAbdu3UK9evVy3faJEycwf/583L59G5qammjfvj1WrVoFe3t7WZ1169bhl19+QVRUFGxtbTF79myMGDEi3/jCwsIwc+ZMXLt2DSKRCC1btsSKFSvQqFEjWZ2IiAj4+PggLCwMZmZm8PX1xTfffFPUQ4JevXohIyMDx48fV1h27tw5tG/fHjdv3ixfD0khoipv3LhxkEgkaN++PaysrBAXF4edO3fi3r17WLVqFXR1dQFkP+G2SZMmGDJkCBwdHQFkX8OPHj0KDw8PeHp6Fmh7V69exeLFixXKO3bsKDfpeH66du0KdXV19OrVC+PGjUNSUhJ+/fVXmJubIzY2Vq5us2bN4Ofnh8WLF6NWrVowNzdH586dMXPmTPz222/o1q0bJk+eDGNjYwQGBiIyMhJ//vlniU1IvmjRIpw9exY9evSAnZ0d4uPjsX79elhbWxd4f4mobDApRRWeRCLBu8Rk1O7QD/om1UpnG69f4GHon5BIJExKEVUiHh4esju8cXFxmDNnDnr27ImnT58qObLcpaenY8CAAXBxccl3XsZRo0bhypUriIiIUFgWGRkJT09PTJs2DTt37kRCQgKmTp2Kvn37Ivz/H9rh5+eHWbNm4ddff0WLFi3w999/Y8yYMTAyMkKvXr1y3WZSUhI8PDzQu3dvrF+/HpmZmZg/fz7c3d3x7NkzqKmpQSKRoGvXrnB1dcWGDRvwzz//YNSoUTA0NMTYsWOLdExGjx6Nfv36ITo6GtbW1nLL/P390bx5cyakiKjcGTRoELZs2QI/Pz+8fv0aenp6aNasGZYvX47evXvL6hkaGqJnz544deoUAgMDkZWVhVq1amHJkiWYPn16gZM4V65cwZUrVxTKv/vuuwInaerWrYs9e/Zgzpw5mD59OiwsLDBhwgSYmZkpPA1v3rx5ePLkCVasWIHExER06NABnTt3RrVq1XDx4kXMmDEDP//8M1JTU+Hs7IxDhw6hR48eBYqjIHr37o2oqChs3boVr169gqmpKTp06ICFCxd+8gmBRFS2RMKnHu1QwUkkEhgYGCAhIQH6+volvwFrayAmBrCyAqKjS759+qTHjx9j+KjxaNZ3IoyrWX96hSJ48yIa1/aux46tG+Dg4FCyjb84A2SlASoaQLWOJds2USlLTU1FZGQkatSoAU1NTWWHUyje3t549+4d9u/fLys7f/482rVrh/j4eFkC+tmzZ/j6669x8uRJiMVitGvXDj/99JOsV9GZM2fwzTff4Pbt21BTU4OTkxOCgoIQEhKCkSNHym3T398f3t7exY49ICAAU6ZMybWnVI68emnt2bMHQ4YMQVpamuzLzKFDh+Dp6Ym0tDSoqamhdevWaNOmDVauXClb7+uvv8aVK1dw/vz5XLd39epVtGjRAk+fPpU9Femff/6Bs7MzHj58iFq1asHPzw+zZ89GXFwc1NXVAQAzZ87E/v37ZfOJ5ObWrVv43//+h3PnzkFHRwddu3bFjz/+CFNTU2RmZsLa2hqTJk3CnDlzZOskJSXB0tISK1euxPjx4/M9nh/L77wu9c8VRERERFVIyfSPJKKiuzgcOOOR/ZOIlCYpKQk7duxArVq1YGJiAiB7fg93d3fo6enh3LlzuHDhAnR1deHh4YH09HRkZmaiT58+6NChAyIiInDp0iWMHTsWIpEIgwYNwtdffw0nJyfExsYiNjYWgwYNApCdEOvYsaNS9rNZs2YQi8Xw9/dHVlYWEhISsH37dri6ukJNTQ1A9nwbHydjtLS08PfffyMjIyPXduvWrQsTExNs2bIF6enpSElJwZYtW1CvXj1ZAu/SpUto3769LCEFAO7u7rh//z7evn2ba7vv3r1D586d0aRJE1y9ehXHjx/HixcvMHDgQACAqqoqRowYgYCAALl5Tnbv3o2srCwMGTKkyMeKiIiIiEoXh+8REVHpWL06+/UpTZsCBw/Kl/XuDfz/ULJ8TZuW/Sqiw4cPy+bteP/+PSwtLXH48GFZD6Jdu3ZBKpVi8+bNsicJ+fv7w9DQEGfOnEHz5s2RkJCAnj17ynpR1qtXT9a+rq4uVFVVYWFhIbddS0vLUnl0dkHUqFEDJ0+exMCBAzFu3DhkZWXBxcUFR48eldVxd3fH5s2b0adPHzRt2hTXrl3D5s2bkZGRgVevXsHS0lKhXT09PZw5cwZ9+vTBd999BwCoXbs2Tpw4AVXV7I8bcXFxqFFD/uEO1apVky0zMjJSaPeXX35BkyZNsGTJElnZ1q1bYWNjgwcPHqBOnToYNWoUVq5cidDQUFmyz9/fH/369eMwDSIiIqJyjEmp4po2DZBIAHbhp6JynAZkSAA1nkNUyUgk2cObP+X/h3rJefmyYOsW86mbnTp1gp+fHwDg7du3WL9+Pbp164a///4bdnZ2uHnzJh49eqTw1KPU1FQ8fvwYXbt2hbe3N9zd3eHm5gZXV1cMHDgw16TNh5YuXZrv8vHjx2PHjh2y90lJSUXcQ0VxcXEYM2YMvLy8MGTIECQmJmLevHno378/Tp06BZFIhLlz5yIuLg6fffYZBEFAtWrV4OXlhRUrVuQ5f0lKSgpGjx6NNm3a4LfffkNWVhZ++OEH9OjRA2FhYdDS0ipSvDdv3kRISIgsefihx48fo06dOnB0dETr1q2xdetWdOzYEY8ePcK5c+ewaNGiIm2TiIiIiMoGk1LFVYw79EQAgHo8h6iS0tfPnm/vU3J7eICZWcHWLeYNAR0dHdSqVUv2fvPmzTAwMMCvv/6KxYsXIykpCc2aNcPOnTtzCTE7bn9/f0yePBnHjx/Hrl27MGfOHJw6dQqfffZZkeNatGgRpk+fXuT187Nu3ToYGBhgxYoVsrIdO3bAxsYGV65cwWeffQYtLS1s3boVGzduxIsXL2BpaYlNmzZBT08vz4c9BAUFISoqCpcuXZIlroKCgmBkZIQDBw5g8ODBsLCwwIsXL+TWy3n/cW+yHElJSejVqxeWL1+usOzD5N/o0aPh6+uLdevWwd/fHw4ODujQoUPhDg4RERERlSkmpYiIqHQUZ2jdx8P5yohIJIJYLEZKSgoAoGnTpti1axfMzc3zndS6SZMmaNKkCWbNmgUXFxcEBQXhs88+g7q6OrKysgodh7m5OczNzYu8H/lJTk5W6O2koqICAApDCtXU1GRPtPv999/Rs2fPPHtK5bSbM8wRgOx9TrsuLi6YPXs2MjIyZPNXnTp1CnXr1s116B6Q/Tv4888/YW9vLxsGmJuBAwfiq6++QlBQELZt24YJEybIxUJERERE5Q8nOicioiorLS0NcXFxiIuLw927d+Hr6yvrmQMAw4YNg6mpKTw9PXHu3DlERkbizJkzmDx5MqKjoxEZGYlZs2bh0qVLePLkCU6ePImHDx/K5pWyt7dHZGQkbty4gVevXiEtLQ0AMGvWLIwYMaLQ8T59+hQ3btzA06dPkZWVhRs3buDGjRtyw/sePXqEGzduIC4uDikpKbI66enpACAbTrdo0SI8fPgQ4eHhGDlyJOzs7NCkSRMAwIMHD7Bjxw48fPgQf//9NwYPHoxbt27Jzeu0b98+ODo6yt67ubnh7du38PHxwd27d3H79m2MHDkSqqqq6NSpEwBg6NChUFdXx+jRo3H79m3s2rULP/30E6blk7z08fHBmzdvMGTIEISFheHx48c4ceIERo4cKZfw09XVxaBBgzBr1izExsaWyFMOiYiIiKh0sadUcSUmAoIAiETAR3OOEBFR+Xb8+HHZEDA9PT04Ojpi9+7dssmytbW1cfbsWcyYMQN9+/ZFYmIirKys0KVLF+jr6yMlJQX37t1DYGAgXr9+DUtLS/j4+GDcuHEAgH79+mHv3r3o1KkT3r17B39/f3h7eyM2NhZPnz4tdLzz5s1DYGCg7H1OEikkJEQW85dffonQ0FCFOpGRkbC3t0fnzp0RFBSEFStWYMWKFdDW1oaLiwuOHz8um/cpKysLq1atwv3796GmpoZOnTrh4sWLsqfoAUBCQgLu378ve+/o6IhDhw5h4cKFcHFxgVgsRpMmTeSOsYGBAU6ePAkfHx80a9YMpqammDdvHsaOHZvnPlevXh0XLlzAjBkz0LVrV6SlpcHOzg4eHh4KvbZGjx6NLVu2oHv37qhevXqhj29VJ5VK8fz5c+jp6bGXGRERERWLIAhITExE9erV8+xpDwAi4cPnJ1dCEokEBgYGSEhIyHfoRZFZW2dPxmtlBURHl3z79EmPHz/G8FHj0azvRBhXsy6Vbbx5EY1re9djx9YNsidslZijzkBKLKBlCXSPKNm2iUpZamoqIiMjUaNGDWhqaio7HKISkd95XeqfK5QoOjoaNrk9eICIiIioiJ49eyabDiI37ClFpGxpb4C0V4BYQ9mREBFRFZbzlMlnz55VuoQbERERlS2JRAIbGxuFp1h/jEkpImXTtQdUNAGt3J88RUREVBZyhuzp6+szKUVEREQl4lNTAjApRaRsbueVHQERERERERFRmePT94iIiIiIiIiIqMyxpxQREREREZULgiAgLi4OEokE+vr6sLCw4NMgiajIeE0p/5iUIiIiIqJSxy8GlB9BEBB8PBj7A/dD/EoMTakmUsWpkJpK0cerD1w9XHm+kAyvJ/QpvKZUHExKESnbPwuB9ARA3QBoOF/Z0RAREZUofjGgTxEEAWuXr0X0sWh8pvsZVLX++4qSmZiJk8tO4m7EXfh+48tzpYrj9YQKgteUioVJKSJle/QrkBIDaFkxKUVERJUKvxhQQQQfD0b0sWg01W+qsExVrIqm+k0RfjQcwY2C4ebhpoQIqTz4+HqioqmCd2nvkJKZAvWX6jix9ASvJwSA15SKhhOdExEREVGp+PCLgapY/l5ozheDZ0efIfhEsJIiJGUTBAH7A/fDWdc533rOus44sO1AGUVF5VHO9aSJXhPce3UPQdeDcObGGdz85ybORZzDvcf3cGH7BZw6fkrZoZIS8ZpS8bCnVHEdOACkpwPq6sqOhCqqDgeArHRAhecQERFVHjlfDD7T/SzfejlfDHi3umqKi4uD+JVYrhddblTFqhDFixAbGwtLS8syio7Ki5zrSSudVgh+FIysl1loq9JWLtmdmZGJ289vY/ms5XDzcGNvqSqK15SKhz2liqtZM8DFJfsnUVEYNwPMXLJ/ElGZ8fb2hkgkwvjx4xWW+fj4QCQSwdvbu+wDK6JNmzahY8eO0NfXh0gkwrt37xTqfP/992jdujW0tbVhaGiosDwgIAAikSjXV3x8vKxeWloaZs+eDTs7O2hoaMDe3h5bt279ZIwBAQFwdnaGpqYmzM3N4ePjI7f8xIkT+Oyzz6CnpwczMzP069cPUVFRhT0UMr6+vqhXr16uy54+fQoVFRUcPHiwyO1T/mRfDMQF/2JAVY9EIoGmVLNAdTUFTSQmJpZyRFQe5VxP7r++j6yXWWio2hCqoo96X4pU0UitEfSi9PBH0B9KipSUjdeUiodJKSIiqrJsbGzw+++/IyUlRVaWmpqKoKAg2NraKjGywktOToaHhwe+/fbbPOukp6djwIABmDBhQq7LBw0ahNjYWLmXu7s7OnToAHNzc1m9gQMH4q+//sKWLVtw//59/Pbbb6hbt26+8a1evRqzZ8/GzJkzcfv2bQQHB8Pd3V22PDIyEp6enujcuTNu3LiBEydO4NWrV+jbt28hj8R/Ro8ejXv37uHixYsKywICAmBubo7u3bsXuX3KH78YUEHo6+sjVZxaoLqpolTo6emVckRUHkkkEmhkaeBm9E3UU8n9ZkOO+ir1cfS3o2UUGZU3vKZUPExKERFRldW0aVPY2Nhg7969srK9e/fC1tYWTZo0kasrlUqxdOlS1KhRA1paWmjUqBH27NkjW56VlYXRo0fLltetWxc//fSTXBve3t7o06cPfvjhB1haWsLExAQ+Pj7IyMgo9r5MmTIFM2fOxGef5T1UauHChZg6dSoaNmyY63ItLS1YWFjIXioqKjh9+jRGjx4tq3P8+HGEhobi6NGjcHV1hb29PVxcXNCmTZs8t/v27VvMmTMH27Ztw9ChQ+Hg4ABnZ2f07t1bVufatWvIysrC4sWL4eDggKZNm2L69Om4ceNGvsfn2bNnGDhwIAwNDWFsbAxPT09Z76rGjRujadOmCr24BEFAQEAAvLy8oKrKmQxKC78YUEFYWFhAaipFpjQz33qZ0kwI5gKH2VRR+vr6eJP5Btrp2go9pD4mEougmaDJ3pdVFK8pFQ+TUsV1+DCwe3f2T6KiePcP8CY8+ycRlblRo0bB399f9n7r1q0YOXKkQr2lS5di27Zt2LBhA27fvo2pU6di+PDhCA0NBZCdtLK2tsbu3btx584dzJs3D99++y3++EN+CEFISAgeP36MkJAQBAYGIiAgAAEBAbLlCxYsgL29fansa2Ft27YN2tra6N+/v6zs4MGDaN68OVasWAErKyvUqVMH06dPl+tt9rFTp05BKpUiJiYG9erVg7W1NQYOHIhnz57J6jRr1gxisRj+/v7IyspCQkICtm/fDldXV6ipqeXabkZGBtzd3aGnp4dz587hwoUL0NXVhYeHB9LT0wFk95b6448/8P79e9l6Z86cQWRkJEaNGlXcQ0T54BcDKgiRSIQ+Xn0QkRSRb72I9xHwHOFZRlFReWNhYYFUvVRoCBr51hMgQFAXoK+uz96XVRSvKRUPk1LFNX48MHBg9k+iogjpBhxvlv2TqDK5uxrYZ539enFGfllS5H/Lrvoqrhva+7/lH/s34L9lz/YqLi+k4cOH4/z583jy5AmePHmCCxcuYPjw4XJ10tLSsGTJEmzduhXu7u6oWbMmvL29MXz4cGzcuBEAoKamhoULF6J58+aoUaMGhg0bhpEjRyokpYyMjPDLL7/A0dERPXv2RI8ePfDXX3/JlpuamsLBwaHY+1UStmzZgqFDh0JLS0tW9u+//+L8+fO4desW9u3bhzVr1mDPnj2YOHFinu38+++/kEqlWLJkiaz+mzdv4ObmJkse1ahRAydPnsS3334LDQ0NGBoaIjo6WuH4fWjXrl2QSqXYvHkzGjZsiHr16sHf3x9Pnz7FmTNnAABDhw5FRkYGdu/eLVvP398fbdu2RZ06dYp5hCg//GJABeXq4QrrbtYIl4QrJDEzpZkITwyHTTcbuLq7KilCUjaRSITew3rjZdbLfOtJMiWwsLZg78sqjteUioV91omIqHRkSICUmOx/Z6XJLxOy/luW/lZx3dSX/y3/WOb7/5ZlJhc7TDMzM/To0QMBAQEQBAE9evSAqampXJ1Hjx4hOTkZbm7yTwdLT0+XG+a3bt06bN26FU+fPkVKSgrS09PRuHFjuXWcnJygoqIie29paYl//vmvp+SkSZMwadKkPONdsmQJlixZInt/586dUpn/6tKlS7h79y62b98uVy6VSiESibBz504YGBgAyJ4vqn///li/fr1cAuvDdTIyMrB27Vp07doVAPDbb7/BwsICISEhcHd3R1xcHMaMGQMvLy8MGTIEiYmJmDdvHvr3749Tp07l+hSlmzdv4tGjRwpfPFJTU/H48WMAgKGhIfr27YutW7fC29sbEokEf/75J9atW1cix4ny5+rhijs37yD8WDicdZ3ln5QlzUTE+wh+MSCIRCJMnjEZwY2DcWDbAYjiRdAUNJEqSoVgLsDT1xOu7q58mloVN3DIQGxZsQVvnr2BkZoRRPjvfBAgQJIpgZa5FgxNDSEYsPdlVcZrSsWi1KSUn58f/Pz8ZHM/ODk5Yd68eejWLbvHSGpqKr7++mv8/vvvSEtLg7u7O9avX49q1aopMWqiElbTC0h/B6gbKjsSopKlpg9oWWX/W+Wj7vYilf+WqRsprqtp9t/yj6nq/LdMVbtEQh01apQsEZRbsiIpKQkAcOTIEVhZyceloZG9b7///jumT5+OVatWwcXFBXp6eli5ciWuXLkiV//joWgikQhSqbTAsY4fPx4DBw6Uva9evXqB1y2MzZs3o3Hjxmj20dNlLS0tYWVlJUtIAUC9evUgCAKio6NRu3ZthbZyvhjUr19fVmZmZgZTU1M8ffoUQPZxNzAwwIoVK2R1duzYARsbG1y5ciXXubKSkpLQrFkz7Ny5U2GZmZmZ7N+jR49Gly5d8OjRI4SEhEBFRQUDBgwo6KGgYuAXAyookUgENw83uHm4ITY2FomJidDT02NigWTEYjH+t/R/2DVjF/AGEKWLIBbEkIqkENQFWNhbwNTcFNcTr8PTl70vqzpeUyoOpSalrK2tsWzZMtSuXRuCICAwMBCenp64fv06nJycMHXqVBw5cgS7d++GgYEBJk2ahL59++LChQvKDJuoZDX6XtkREJWOetOyX7nRrQF8Hp33uh0O5r2spnf2qwTlzEEkEonkngiXo379+tDQ0MDTp0/RoUOHXNu4cOECWrduLTeMLae3TkkyNjaGsbFxibf7oaSkJPzxxx9YunSpwrI2bdpg9+7dSEpKgq6uLgDgwYMHEIvFsLbOZbjl/68DAPfv35fVefPmDV69egU7OzsA2U8PFIvlZxXI6VGWV9KuadOm2LVrF8zNzaGvr5/n/nTq1Ak1atSAv78/QkJCMHjwYOjo6OR3CKgE8YsBFZalpSXPD8qVWzc33I24i+hj0aijWgcQAFUVVWhqaiJTmonridfZ+5IU8JpSvil1TqlevXqhe/fuqF27NurUqYPvv/8eurq6uHz5MhISErBlyxasXr0anTt3RrNmzeDv74+LFy/i8uXLygybiIgqGRUVFdy9exd37tyRG1qXQ09PD9OnT8fUqVMRGBiIx48fIzw8HD///DMCAwMBALVr18bVq1dx4sQJPHjwAHPnzkVYWFihY/nll1/QpUuXQq8XFxeHGzdu4NGjRwCAf/75Bzdu3MCbN29kdZ4+fYobN27g6dOnyMrKwo0bN3Djxg1ZT7Acu3btQmZmpsLcWkD2HE0mJiYYOXIk7ty5g7Nnz+J///sfRo0aJRu6t2/fPjg6OsrWqVOnDjw9PfHVV1/h4sWLuHXrFry8vODo6IhOnToBAHr06IGwsDAsWrQIDx8+RHh4OEaOHAk7OzuFJyHmGDZsGExNTeHp6Ylz584hMjISZ86cweTJkxEd/V/SUyQSYdSoUfDz88OlS5fkniZIZcvS0hJ16tThlwMiKpKc3pddZ3XFzWo3ESGOwB3pHVxMuYgrBlfQdWZX+H7jy96XRBVIuZlTKisrC7t378b79+/h4uKCa9euISMjA66u/2W5HR0dYWtri0uXLuX5yOu0tDSkpf03d4lEIin12ImIqOLLr6cNAHz33XcwMzPD0qVL8e+//8LQ0BBNmzbFt99+CwAYN24crl+/jkGDBkEkEmHIkCGYOHEijh07Vqg4Xr16VaQeVhs2bMDChQtl79u3bw8ge1Jvb29vAMC8efNkSTQAsmRPSEgIOnbsKCvfsmUL+vbtC0NDQ4Xt6Orq4tSpU/D19UXz5s1hYmKCgQMHYvHixbI6CQkJuH//vtx627Ztw9SpU9GjRw+IxWJ06NABx48flw1n7Ny5M4KCgrBixQqsWLEC2tracHFxwfHjx3OdpwoAtLW1cfbsWcyYMQN9+/ZFYmIirKys0KVLF4Xfp7e3N+bPnw8nJye0atXqE0eTiIjKK/a+JKpcRIIgCMoM4J9//oGLiwtSU1Ohq6uLoKAgdO/eHUFBQRg5cqRcggkAWrZsiU6dOmH58uW5trdgwQK5D+U5EhISPvmFo0isrYGYGMDKCojOZygKlZrHjx9j+KjxaNZ3Ioyr5T50pLjevIjGtb3rsWPrhnLzVCyi8iA1NRWRkZGoUaMGNDU1lR0OUYnI77yWSCQwMDAovc8VSlSZ942IiIjKVkE/Vyh1+B4A1K1bFzdu3MCVK1cwYcIEeHl54c6dO0Vub9asWUhISJC9nj17VoLREpWCvzoDR5yyfxIRERERERFVEUofvqeuro5atWoBAJo1a4awsDD89NNPGDRoENLT0/Hu3Tu54QMvXryAhYVFnu1paGjInoREVCFIHmQ/3j49QdmREBEREREREZUZpfeU+phUKkVaWhqaNWsGNTU1/PXXX7Jl9+/fx9OnT+Hi4qLECD+iqwvo6WX/JCoKNV1AVS/7JxEREREREVEVodSeUrNmzUK3bt1ga2uLxMREBAUF4cyZMzhx4gQMDAwwevRoTJs2DcbGxtDX14evry9cXFzynORcKe7dU3YEVNH15DlEREREREREVY9Sk1Lx8fEYMWIEYmNjYWBgAGdnZ5w4cQJubm4AgB9//BFisRj9+vVDWloa3N3dsX79emWGTEREuVDyMzOIShTPZyIiIqKyodSk1JYtW/JdrqmpiXXr1mHdunVlFBERERWGmpoaACA5ORlaWlpKjoaoZCQnJwP47/wmIiIiotKh9InOiYio4lJRUYGhoSHi4+MBANra2hCJREqOiqhoBEFAcnIy4uPjYWhoCBUVFWWHRERERFSpMSlVXP/7H/D2LWBkBKxcqexoqCK6/wuQmZg92XndScqOhqjQcp6ImpOYIqroDA0N833SLxERERGVDCaliuu334CYGMDKikkpKpo7y4CUGEDLikkpqpBEIhEsLS1hbm6OjIwMZYdDVCxqamrsIUVERERURpiUIiKiEqGiosIv80REREREVGBMShEp22dbgaxUQEVT2ZEQERERERERlRkmpYiUzbKrsiMgIiIiIiIiKnNiZQdARERERERERERVD5NSRERERERERERU5jh8jwAAL1++hEQiKbX29fX1YWZmVmrtV2gpsYCQBYhUAC1LZUdDREREREREVCaYlCK8fPkSI0Z+iXeJyaW2DUM9bWzz38zEVG6OtwBSYgAtK+DzaGVHQ0REFVBWVhYWLFiAHTt2IC4uDtWrV4e3tzfmzJkDkUik7PCIiIiIcsWkFEEikeBdYjJqd+gHfZNqJd/+6xd4GPonJBIJk1JERESlYPny5fDz80NgYCCcnJxw9epVjBw5EgYGBpg8ebKywyMiIiLKFZNSxdWjB/DmDWBsrOxIik3fpBqMq1krO4yqx6oHkPYG0Kj45xARESnHxYsX4enpiR49egAA7O3t8dtvv+Hvv/9WcmREREREeWNSqrg2blR2BFTRteQ5RERExdO6dWts2rQJDx48QJ06dXDz5k2cP38eq1evznOdtLQ0pKWlyd6X5tySRERERLlhUoqIiIiogps5cyYkEgkcHR2hoqKCrKwsfP/99xg2bFie6yxduhQLFy4swyiJiIiI5ImVHQARERERFc8ff/yBnTt3IigoCOHh4QgMDMQPP/yAwMDAPNeZNWsWEhISZK9nz56VYcRERERE7ClFREREVOH973//w8yZMzF48GAAQMOGDfHkyRMsXboUXl5eua6joaEBDQ2NsgyTiIiISA6TUsXVvDkQFwdYWABXryo7mnIrIz0dT548KZW2nzx5gsyszFJpu0ycGwCkvQQ0zIB2u5UdDRERVUDJyckQi+U7wKuoqEAqlSopIiIiIqJPY1KquOLigJgYZUdRrqUkJSAy8l/8b/YCqKuX/B3Z1JRkxMTGoml6Rom3XSZeXQJSYgAtK2VHQkREFVSvXr3w/fffw9bWFk5OTrh+/TpWr16NUaNGKTs0IiIiojwxKUWlLj01BYJYFQ5t+8Lc2q7E2495eAtP9m5FZmYFTUoREREV088//4y5c+di4sSJiI+PR/Xq1TFu3DjMmzdP2aERERER5YlJKSozesZmMK5mXeLtJryKK/E2y1Tvx8qOgIiIKjg9PT2sWbMGa9asUXYoRERERAXGpBSRsqlwklkiIiIiIiKqepiUIiIiIiKickcQBMTFxUEikUBfXx8WFhYQiUTKDouIKiBeT8ovJqWIiIiIiKjcEAQBwceDsT9wP8SvxNCUaiJVnAqpqRR9vPrA1cOVXyaJqEB4PSn/mJQiUraoICAzGVDVBuyHKjsaIiKiUsW71f/58Fjo6ekBABITE6v0cREEAWuXr0X0sWh8pvsZVLX++7qSmZiJk8tO4m7EXfh+41sljw/J4/VEHo+HPF5P8j4nytO5wqQUkbJd/wZIiQG0rJiUIiKiSot3q//z4bEQvRTh5auXePLiCfQFfdhY2EDbTLtKHhcACD4ejOhj0Wiq31RhmapYFU31myL8aDiCGwXDzcNNCRFSecDriTwej9xV5etJfueEbX1bPLn9BCqvVcrFucKkFBERERGVKt6t/s+Hx6KVTiuciTkDzZea6KPSByoiFUiiJdBK14K1hnWVOi5A9rHZH7gfn+l+lm89Z11nHNh2oNJ9iaSC4fVEHo9H7qry9SSvc0KAgIc3HuLKsSvQt9RH11pdZeeEMs8VcZltqbJasQL49dfsn0RF0WQF0PLX7J9ERESV0Id3q1XF8vdEc+5WPzv6DMEngpUUYdn58Fjcf30fWS+z0FC1IVRFqhBBBANVA6TEp+Ddq3dV6rgAQFxcHMSvxArnyMdUxaoQxYsQGxtbRpFRecLriTwej9xV5etJXufEq/hXyHyZidaarSG8FHD75W3ZMmWeK0xKFdfQocCXX2b/JCoK+6FArS85dI+IiCqlnLvVzrrO+dbLuVtdmX14LARBwM3om6inUk+hnr6qPuKi4wBUjeOSQyKRQFOqWaC6moImEhMTSzkiKm94PZHH45G3qno9yeucECAgLjoO+qr6AIB6KvUQER2hsL4yzhUmpYiIiIio1FTlu9Uf+/BYvEt7B+10baiKFI+LCCKI0kVITU2tEsclh76+PlLFqQWqmypKlU0OT1UHryfyeDzyVlWvJ3mdE2mpaRCliyBC9rA8VZEqtNK18Db1rVw9ZZwrSk1KLV26FC1atICenh7Mzc3Rp08f3L9/X65Ox44dIRKJ5F7jx49XUsREREREVBhV9W51bj48FimZKdAU8j4uYkGMzKxMAJX/uOSwsLCA1FSKTGlmvvUypZkQzAVYWlqWUWRUXvB6Io/HI29V9XqS1zmRmZkJsSCf/tEUNJGaqZi4K+tzRalJqdDQUPj4+ODy5cs4deoUMjIy0LVrV7x//16u3pgxYxAbGyt7rShP8zfdvw/cvp39k6gostL+exEREVUyVfVudW4+PBZaqlpIFeV9XKQiKVRVsu90V/bjkkMkEqGPVx9EJCkOKflQxPsIeI7wLKOoqDzh9UQej0fequr1JK9zQlVVFVKRVK4sVZQKTVXFBFZZnytKffre8ePH5d4HBATA3Nwc165dQ/v27WXl2trasLCwKOvwCqZLFyAmBrCyAqKjlR0NVUQHHYCUGEDLCvic5xAREVUusrvViZn5DjGpbHerc/PhsTDUMESyejIyMzIVhvAJECCoC9DU1KwSx+VDrh6uuHPzDsKPhcNZ11nunMmUZiLifQRsutnA1d1ViVGSsvB6Io/HI39V8XqS1zmhoakBQV2AkClABBEyhUykqKfASNNIbn1lnCvlak6phIQEAICxsbFc+c6dO2FqaooGDRpg1qxZSE5OzrONtLQ0SCQSuRcRERERKUdVvVudmw+PhUgkQiPrRribdVehniRTAgvr7BuyVeG4fEgkEmHyjMnoOqsrrhhcwcWUiwhPDsfFlIu4YnAFXWd2rXKPtqf/8Hoij8cjf1XxepLXOSGCCBbWFpBkZudH7mbdhbO14gT5yjhXlNpT6kNSqRRTpkxBmzZt0KBBA1n50KFDYWdnh+rVqyMiIgIzZszA/fv3sXfv3lzbWbp0KRYuXFhWYRMVn6kLkPYS0DBTdiRERESloirerc7Lh8eioUlDxCbE4p+X/6CeSj2oiFQgyZRAy1wLhqaGCE8MrzLH5UMikQhuHm5w83BDbGwsEhMToaenV+V6eVDueD2Rx+ORv6p4PcnrnDA1N8XbhLe4GHcR+hb6cDJzkq2jzHOl3CSlfHx8cOvWLZw/f16ufOzYsbJ/N2zYEJaWlujSpQseP34MBwcHhXZmzZqFadOmyd5LJBLY2NiUXuBExdVut7IjICIiKlU5d6uDGwfjwLYDEMWLsidYFaVCMBfg6esJV3fXSnW3Oi8fHwttK2281HiJ/S/2Qx/6sLGxgbapNp4bPK9SxyUvlpaWlfrLIxUeryfyeDwKrqpcT/I7J6RNpGjl1ApPbz/FpZeXysW5Ui6SUpMmTcLhw4dx9uxZWFtb51u3VatWAIBHjx7lmpTS0NCAhoZGqcRJREREREVTFe9W5yWvYwGgSh8XooLi9UQejwd9rCDnRHk5V5SalBIEAb6+vti3bx/OnDmDGjVqfHKdGzduAAD/gxERERFVUFXlbnVBfHwseFyICofXE3k8HvSxvM6J8nKuKDUp5ePjg6CgIBw4cAB6enqIi4sDABgYGEBLSwuPHz9GUFAQunfvDhMTE0RERGDq1Klo3749nJ0VJ+UiIiIiIiIiIqKKQalJKT8/PwBAx44d5cr9/f3h7e0NdXV1BAcHY82aNXj//j1sbGzQr18/zJkzRwnREpWSv8cBaW8ADWOg5UZlR0NERERERERUJpQ+fC8/NjY2CA0NLaNoiJQk5giQEgNoWSk7EiIiIiIiIqIyI1Z2AEREREREREREVPWUi6fvVWhhYUBWFqCiouxIqKLyCAOELEDEc4iIiIiIiIiqDialiqsczFZPFZwWzyEiIiIiIiKqejh8j4iIiIiIiIiIyhyTUkREREREREREVOY4fK+4Nm0CkpIAXV1g7FhlR0MVUexJICsVUNEELLsqOxoiIiIiIiKiMsGkVHEtWgTExABWVkxKUdFcHgWkxABaVsDn0cqOhoiIiIiIiKhMcPgeERERERERERGVOfaUIlK2+jOBzERAVU/ZkRARERERERGVGSaliJSt7iRlR0BERERERERU5jh8j4iIiIiIiIiIyhyTUkREREREREREVOaYlCIiIiIiIiIiojLHOaWIlO2wI5D8HNCuDvS8p+xoiIiIiIiIiMoEe0oRKVtGUvbT9zKSlB0JERERERERUZlhUqq46tQB6tfP/klUFPp1AIP62T+JiIiKKCYmBsOHD4eJiQm0tLTQsGFDXL16VdlhEREREeWJw/eK6/RpZUdAFV0XnkNERFQ8b9++RZs2bdCpUyccO3YMZmZmePjwIYyMjJQdGhEREVGemJQiIiIiquCWL18OGxsb+Pv7y8pq1KihxIiIiIiIPo3D94iIiIgquIMHD6J58+YYMGAAzM3N0aRJE/z666/5rpOWlgaJRCL3IiIiIipLTEoRERERVXD//vsv/Pz8ULt2bZw4cQITJkzA5MmTERgYmOc6S5cuhYGBgexlY2NThhETERERcfhe8Q0bBrx6BZiaAjt3KjsaqohuzgbS3wHqhkCj75UdDRERVUBSqRTNmzfHkiVLAABNmjTBrVu3sGHDBnh5eeW6zqxZszBt2jTZe4lEwsQUERERlSkmpYorNBSIiQGsrJQdCVVU/wYCKTGAlhWTUkREVCSWlpaoX7++XFm9evXw559/5rmOhoYGNDQ0Sjs0IiIiojxx+B4RERFRBdemTRvcv39fruzBgwews7NTUkREREREn8aeUkTK1ukYIM0AxGrKjoSIiCqoqVOnonXr1liyZAkGDhyIv//+G5s2bcKmTZuUHRpRkQiCgLi4OEgkEujr68PCwgIikUjZYRERUQljUopI2QwbKjsCIiKq4Fq0aIF9+/Zh1qxZWLRoEWrUqIE1a9Zg2LBhyg6NqFAEQUDw8WDsD9wP8SsxNKWaSBWnQmoqRR+vPnD1cGVyipi0JKpEmJQiIiIiqgR69uyJnj17KjsMoiITBAFrl69F9LFofKb7GVS1/vuqkpmYiZPLTuJuxF34fuPLBEQVxaQlUeXDpBQRERERESld8PFgRB+LRlP9pgrLVMWqaKrfFOFHwxHcKBhuHm5KiJCUiUlLosqJE50TKduba8DLS9k/iYiIiKogQRCwP3A/nHWd863nrOuMA9sOlFFUVJ58mLRUFcv3rchJWj47+gzBJ4KVFCERFYVSk1JLly5FixYtoKenB3Nzc/Tp00fhyTGpqanw8fGBiYkJdHV10a9fP7x48UJJEROVglBP4FTr7J9EREREVVBcXBzEr8QKyYaPqYpVIYoXITY2towio/KASUuiykupSanQ0FD4+Pjg8uXLOHXqFDIyMtC1a1e8f/9eVmfq1Kk4dOgQdu/ejdDQUDx//hx9+/ZVYtRERERERFSSJBIJNKWaBaqrKWgiMTGxlCOi8oRJS6LKS6lzSh0/flzufUBAAMzNzXHt2jW0b98eCQkJ2LJlC4KCgtC5c2cAgL+/P+rVq4fLly/js88+U0bY8saMARISAAMDZUdCFVWtMUB6AqDOc4iIiIiqJn19faSKUwtUN1WUCj09vVKOiMqToiQtLS0tSzkqIioJ5Wqi84SEBACAsbExAODatWvIyMiAq6urrI6joyNsbW1x6dKl8pGUmj9f2RFQRdeQ5xARERFVbRYWFpCaSpGZmJlvb5hMaSYEc4EJhyqGSUuiyqtIw/dq1qyJ169fK5S/e/cONWvWLFIgUqkUU6ZMQZs2bdCgQQMA2d001dXVYWhoKFe3WrVqiIuLy7WdtLQ0SCQSuRcREREREZVfIpEIfbz6ICIpIt96Ee8j4DmC83BWNbKkpTQz33pMWhJVPEVKSkVFRSErK0uhPC0tDTExMUUKxMfHB7du3cLvv/9epPVzLF26FAYGBrKXjY1NsdojIiIiIqLS5+rhCutu1giXhCskHzKlmQhPDIdNNxu4urvm0QJVVkxaElVehRq+d/DgQdm/T5w4AYMP5lHKysrCX3/9BXt7+0IHMWnSJBw+fBhnz56FtbW1rNzCwgLp6el49+6dXG+pFy9ewMLCIte2Zs2ahWnTpsneSyQSJqaIiIiIiMo5kUiEyTMmI7hxMA5sOwBRvAiagiZSRakQzAV4+nrC1d0VIpFI2aGSErh6uOLOzTsIPxYOZ11nuWGemdJMRLyPYNKSqAIqVFKqT58+ALL/YHh5ecktU1NTg729PVatWlXg9gRBgK+vL/bt24czZ86gRo0acsubNWsGNTU1/PXXX+jXrx8A4P79+3j69ClcXFxybVNDQwMaGhqF2KtisrYGYmIAKysgOrrstkuVx6m2QEocoGUBuJ1XdjRERFRG3r17h3379uHcuXN48uQJkpOTYWZmhiZNmsDd3R2tW7dWdohEZU4kEsHNww1uHm6IjY1FYmIi9PT0OByLmLQkqqQKlZSSSqUAgBo1aiAsLAympqbF2riPjw+CgoJw4MAB6OnpyeaJMjAwgJaWFgwMDDB69GhMmzYNxsbG0NfXh6+vL1xcXMrHJOdEJSEpCkiJAbIKNnkjERFVbM+fP8e8efOwc+dOVK9eHS1btkTjxo2hpaWFN2/eICQkBD/88APs7Owwf/58DBo0SNkhEymFpaUlk1Ekh0lLosqnSE/fi4yMLJGN+/n5AQA6duwoV+7v7w9vb28AwI8//gixWIx+/fohLS0N7u7uWL9+fYlsn6hc0DAGpGnZP4mIqNJr0qQJvLy8cO3aNdSvXz/XOikpKdi/fz/WrFmDZ8+eYfr06WUcJRFR+cakJVHlUKSkFAD89ddf+OuvvxAfHy/rQZVj69atBWpDEIRP1tHU1MS6deuwbt26IsVJVO51z3/CRiIiqlzu3LkDExOTfOtoaWlhyJAhGDJkSK5PPCYiIiKqDIr09L2FCxeia9eu+Ouvv/Dq1Su8fftW7kVEREREuftUQgoAMjMzsW/fvgLXJyIiIqqIitRTasOGDQgICMAXX3xR0vEQlVsZ6el48uRJqbWvr68PMzOzUmufiIjKv5s3byIgIAA7duxAQkIC0tPTlR0SERERUakpUlIqPT2dT4ShKiUlKQGRkf/if7MXQF29dJ7uaKinjW3+m5mYIiKqYt68eYOdO3fC398fN2/eRKdOnbB06VLZU4+JiIiIKqsiJaW+/PJLBAUFYe7cuSUdD1G5lJ6aAkGsCoe2fWFubVeibXfWOghR6ks8fXAXEomESSkiokrq0aNHmDNnDkxMTLBw4UJcuXIFW7duxeHDh+Hk5IRhw4YhIiICa9euzXMCdCIiIqLKpEhJqdTUVGzatAnBwcFwdnaGmpqa3PLVq1eXSHBE5Y2esRmMq1mXaJtdpEdhoBuPeE0NJJZoy0REVJ4MGzYMAwcOhK2tLSwtLWFlZYUhQ4YgPDwcTk5OAICZM2cqOUoiIiKislOkpFRERAQaN24MALh165bcMpFIVOygiIiIiCqbly9fomnTpqhZsyYEQUD79u3RuXNn9ooiIiKiKqtISamQkJCSjqPi2rEDSEsDNEpnniGq/P4ULUTK2+e4ffYIvu6i7GiIiKi0/Pjjj/D29oapqSl+//13XLx4EcOHD4eqqiqGDBmCYcOG8eYeERERVSliZQdQ4XXsCLi7Z/8kKoIoUTPczWiC67HGyg6FiIhKkaenJ548eYJr166hf//+WL16NWJiYvDLL7/g4cOHaNWqFTIzMxEYGIgHDx4oO1wiIiKiUleknlKdOnXK907e6dOnixwQERERUVWhqqqKzz//HJ9//jni4+Oxbds2BAQEYOXKlWjQoAEiIiKUHSIRERFRqSlST6nGjRujUaNGslf9+vWRnp6O8PBwNGzYsKRjJCIiIqr0zM3NMX36dNy6dQuXL19G27ZtlR0SERERUakqUk+pH3/8MdfyBQsWICkpqVgBVThnzvw3pxSH8FERGAoxEItjYamXouxQiIionGjZsiVatmyp7DCIiIiISlWJzik1fPhwbN26tSSbLP+GDwc8PLJ/EhXBaGEcFpj4YEPvq8oOhYiIyoCHhwcuX778yXqJiYlYvnw51q1bVwZREREREZW9IvWUysulS5egqalZkk0SERERVSoDBgxAv379YGBggF69eqF58+aoXr06NDU18fbtW9y5cwfnz5/H0aNH0aNHD6xcuVLZIRMRERGViiIlpfr27Sv3XhAExMbG4urVq5g7d26JBEZUVdxFB4hTX+BJ1L9oquxgiIio1I0ePRrDhw/H7t27sWvXLmzatAkJCQkAAJFIhPr168Pd3R1hYWGoV6+ekqMlIiIiKj1FSkoZGBjIvReLxahbty4WLVqErl27lkhgRFXFUfH/8CYxGtcurMeO0cqOhoiIyoKGhgaGDx+O4f8//D8hIQEpKSkwMTGBmpqakqMjIiIiKhtFSkr5+/uXdBxEREREVZaBgYHCTT8iIiKiyq5Yc0pdu3YNd+/eBQA4OTmhSZMmJRIUERERERERERFVbkVKSsXHx2Pw4ME4c+YMDA0NAQDv3r1Dp06d8Pvvv8PMzKwkYyQiIiIiIiIiokpGXJSVfH19kZiYiNu3b+PNmzd48+YNbt26BYlEgsmTJ5d0jESV2lDp1/jacCZWuN9QdihEREREREREZaZIPaWOHz+O4OBguSfC1K9fH+vWreNE50SFZIn7MFCLh46pBhKVHQwRERERERFRGSlSTympVJrrk2HU1NQglUqLHRQRERFRVeDl5YWzZ88qOwwiIiIipShSUqpz58746quv8Pz5c1lZTEwMpk6dii5dupRYcBVCdDQgCNk/iYpglfgwJr3cC8+d7ZQdChERlbGEhAS4urqidu3aWLJkCWJiYpQdEhEREVGZKVJS6pdffoFEIoG9vT0cHBzg4OCAGjVqQCKR4Oeffy7pGImIiIgqpf379yMmJgYTJkzArl27YG9vj27dumHPnj3IyMgocrvLli2DSCTClClTSi5YIiIiohJWpDmlbGxsEB4ejuDgYNy7dw8AUK9ePbi6upZocERERESVnZmZGaZNm4Zp06YhPDwc/v7++OKLL6Crq4vhw4dj4sSJqF27doHbCwsLw8aNG+Hs7FyKURMREREVX6F6Sp0+fRr169eHRCKBSCSCm5sbfH194evrixYtWsDJyQnnzp0rrViJiIiIKq3Y2FicOnUKp06dgoqKCrp3745//vkH9evXx48//ligNpKSkjBs2DD8+uuvMDIyKuWIiaisCIKA2NhY3L9/H7GxsRAEQdkhERGViEL1lFqzZg3GjBkDfX19hWUGBgYYN24cVq9ejXbtqtDcOAsXAgkJgIEBMH++sqOhCqixcBiZmrGoVuf5pysTEVGlkpGRgYMHD8Lf3x8nT56Es7MzpkyZgqFDh8o+b+3btw+jRo3C1KlTP9mej48PevToAVdXVyxevDjfumlpaUhLS5O9l0gkxdsZKhRBEBAXFweJRAJ9fX1YWFhAJBIpOywqZ6RSKXYH7cbh3w5DW6INfTV9pIpTITWVoo9XH7h6uPK8IQB5X1N4raEPlcfzoVBJqZs3b2L58uV5Lu/atSt++OGHYgdVofz6KxATA1hZMSlFRdJF2AADvXjEt9BAorKDISKiMmVpaQmpVIohQ4bg77//RuPGjRXqdOrUCYaGhp9s6/fff0d4eDjCwsIKtO2lS5di4cKFhYyYiksQBAQfD8b+wP0QvxJDU6rJJAMpEAQBp46dwrKZy6D/VB/1VepDJBZBUBdgY20DQw1DnFx2Encj7sL3G1+eM1VYftcU2/q2eHL7CVReq/BaU8WV5789hUpKvXjxAmpqank3pqqKly9fFjsoIiIioqrgxx9/xIABA6CpqZlnHUNDQ0RGRubbzrNnz/DVV1/h1KlT+bb1oVmzZmHatGmy9xKJBDY2NgULnIpEEASsXb4W0cei8ZnuZ1DV+u+jeGZiJpMMBOC/8+Tijouwem6FRhqN/luWKeDlo5dIkiShSa0muH70OoIbBcPNw02JEZOy5HVNESDg4Y2HuHLsCvQt9dG1VlfZNYXXmqqnvP/tKdScUlZWVrh161aeyyMiImBpaVnsoIiqkqOirxEo+QqrL9ZVdihERFTGvvjiiwInkfJz7do1xMfHo2nTplBVVYWqqipCQ0Oxdu1aqKqqIisrS2EdDQ0N6Ovry72odAUfD0b0sWg01W8KVbH8vWFVsSqa6jfFs6PPEHwiWEkRUnkQfDwYz44+w/u37+Gk6iS3TAQRDFQNkBKfglfxr+Cs64wD2w4oKVJStryuKa/iXyHzZSZaa7aG8FLA7Ze3Zct4ral6yvvfnkIlpbp37465c+ciNTVVYVlKSgrmz5+Pnj17Fri9s2fPolevXqhevTpEIhH2798vt9zb2xsikUju5eHhUZiQicq9u6JOCEvrgNBIc2WHQkREFVSXLl3wzz//4MaNG7JX8+bNMWzYMNy4cQMqKirKDrHKEwQB+wP3w1k3/6ciMslQteWcJ3ZqdtBO14aqKPeBLfqq+oiLjoOqWBWieBFiY2PLOFJStryuKQIExEXHQV81+0ZDPZV6iIiOUFif15qqoSL87SnU8L05c+Zg7969qFOnDiZNmoS6dbN7dty7dw/r1q1DVlYWZs+eXeD23r9/j0aNGmHUqFHo27dvrnU8PDzg7+8ve6+hoVGYkImIiIgqPT09PTRo0ECuTEdHByYmJgrlpBxxcXEQvxLLDZvIzYdJhqo2AqE8TsBb1nLOk3RpOjSFvHtRiiCCKF2E1NRUaAqaSExMrHLnS1WX1zUlLTUNonQRROLs/zuqIlVopWvhbepbGGn+91TWqnCt4TWlYvztKVRSqlq1arh48SImTJiAWbNmyR5FKhKJ4O7ujnXr1qFatWoFbq9bt27o1q1bvnU0NDRgYWFRmDCJiIiIiMoViUQCTWnBhmpWtSRDeZ6At6zlnCdaqlpIFSmOTvmQWBAjMysTqeJU6OnplVGEVF7kdU3JzMyEWJAfEKUpaCI1U/F8qqzXGl5T/lMR/vYUKikFAHZ2djh69Cjevn2LR48eQRAE1K5dG0ZGRp9euQjOnDkDc3NzGBkZoXPnzli8eDFMTExKZVtEyqAuvIemKBnaapnKDoWIiCqRM2fOKDsE+oC+vj5SxfknGXKkiqpOkqG8T8Bb1nLOE0MNQySrJyMzIzPPIXxSkRQQAYK5UOmSCvRpeV1TVFVVs8+ND6SKUqGpqpiYqIzXGl5T5FWEvz2FmlPqQ0ZGRmjRogVatmxZagkpDw8PbNu2DX/99ReWL1+O0NBQdOvWLdfJOnOkpaVBIpHIvYjKM19hEH4wHY7fBl5SdihERERUSiwsLCA1lSJTmv9NqExpZpVKMpT3CXjLWs55kiVkoZF1I9zNuptrPQECBHUBD7IewHOEZxlHSeVBXtcUDU0NCOoCBGSPasoUMpGiniI3dA+ovNcaXlPkVYS/PUVOSpWFwYMHo3fv3mjYsCH69OmDw4cPIywsLN87f0uXLoWBgYHsxUcbExEREZGyiUQi9PHqg4gkxQmHPxTxPqLKJBkqwgS8Ze3D88TJzAkqZir4J/MfZAryXyjfZrzFC5MXsOlmA1d3VyVFS8qU1zVFBBEsrC0gyczunHE36y6crRX/j1XGaw2vKYoqwt+ecp2U+ljNmjVhamqKR48e5Vln1qxZSEhIkL2ePXtWukF16AB07Zr9k6gIotAEd9Mb43ps6fQ4JCIiovLB1cMV1t2sES4JV7hrnSnNRHhieJVKMsgm4BUXfALeqiDnPLmeeB0da3aEdS1rXFC7gL+lf+Nm1k0Epwfjqu1VDFo+qMoMQaLc5XVNMTU3haqZKi6mXYTITAQnMyfZssp8reE1JXfl/W9PoeeUUqbo6Gi8fv063y5lGhoaZfuEvp07y25bVCn9Kf4ObxKice30euwYruxoiIiIqLSIRCJMnjEZwY2DcWDbAYjiRdkTEItSIZgL8PT1hKs7J+DNTWWdkDk3CudJugiOjo54nf4a6Qbp8B7qjUFDBlWZ84Tylt81RdpEilZOrfD09lNcenmpSlxreE3JXXn/26PUpFRSUpJcr6fIyEjcuHEDxsbGMDY2xsKFC9GvXz9YWFjg8ePH+Oabb1CrVi24u7srMWoiIiIioqIRiURw83CDm4cbYmNjkZiYCD09vSrxxehjFWECXmXheUIFVZBzpaqcQ7ym5K08X1OUmpS6evUqOnXqJHs/bdo0AICXlxf8/PwQERGBwMBAvHv3DtWrV0fXrl3x3XfflW1PKCIiIiKiUmBpaVkuvhAoi2wC3sTMfIfbVNYJmQuqqp8nVHB5nStV5RziNaVgytv5oNSkVMeOHSEIQp7LT5w4UYbREBERERFRWcmZgPfkspNoqt80z3oR7yPg6Vu5JmQmopLHa0rFVKEmOi+XOncGnJyyfxIVQR/pIozTX4LZHW8rOxQiIiKiMlXeJ+AlooqF15SKp0JNdF4uPXgAxMQACQnKjoQqKAf8DQONeFSz0kCisoMp516+fAmJRFJq7evr68PMzKzU2iciIiJ55X0CXiKqWHhNqXiYlCKiCuHly5cYMfJLvEtMLrVtGOppY5v/ZiamiIiIylB5noCXiCoeXlMqFialiJRsvWgHEl7G4Pphf6zvouxoyi+JRIJ3icmo3aEf9E2qlXz7r1/gYeifkEgkTEoREREpSXmbgJeIKjZeU8o/JqWIlCxFZIgkIQmSNHVlh1Ih6JtUg3E1a2WHQURERERERMXEic6JiIiIiIiIiKjMMSlFRERERERERERljsP3iJSsjnAOaeqx0LR9qexQiIiIiIiIiMoMk1IVwMuXLyGRSEqt/SdPniAzK7PU2qf89RKWw8AgHi/aqeP2kyelth19fX1O4E1ERERERETlBpNS5dzLly8xYuSXeJeYXGrbSE1JRkxsLJqmZ5TaNujTsjKz8L/ZC6CurlEq7RvqaWOb/2YmpoiIiIiIiKhcYFKquObNA5KSAF3dUmleIpHgXWIyanfoB32TaqWyjZiHt/Bk71ZkZjIppQxnRKORFPcAV8+egUPbvjC3tivxbUhev8DD0D8hkUiYlCIiIiIiIqJygUmp4ho7tkw2o29SDcbVrEul7YRXcaXSLhXMNdHniHxzFUeuXMPnLc1K7fdMREREREREVJ7w6XtERERERERERFTmmJQiIiIiIiIiIqIyx+F7xRUbC2RlASoqgKWlsqMhIiIiIiIiIqoQmJQqrhYtgJgYwMoKiI5WdjRUAU2R9oFe3XjEzAK+S1J2NERERERERP/X3p3HNXHn/wN/TUi5hIDIrahYiwoeKAq6VastilZdqNoqrVUU7bZVrF/atdd69HRbe7hurbargHa1VXqoVYtV1rNe64FHRYoWEZQgqJBwhBAyvz/8kTXlECXJJPB6Ph55aGY+8/m8k8/MmHn7mc8QWQZv3yOSmB10eECmg72dKHUoRERERERERBbDkVJEEruOLrilccAlZRHgJHU0RERERERERJbBkVJEEvtKthwLcl7Hk6t9pQ6FiIiIiIiIyGKYlCIiIiIiIiIiIotjUoqIiIiIiIiIiCyOSSkiIiIiIiIiIrI4TnROJLGR+uXQ+f2O8LE3kSF1MEREREREREQWwqQUkcR64We4uV9HUKgdMkqljoaIiIiIiIjIMnj7HhERERERERERWRxHSjVXejqg0wFyfpV0f1KEFSi4eBr/+TYZvSZLHQ0RERERERGRZTCT0lzdukkdAdm4G0InXNUW4WLRA+gldTBEREREREREFsLb94iIiIiIiIiIyOKYlCIiIiJqAZYsWYIBAwbA1dUV3t7eiImJQVZWltRhAQBEUURBQQGysrJQUFAAURSlDomIiIisgKRJqf3792PcuHHw9/eHIAjYvHmz0XpRFLFw4UL4+fnByckJkZGRyM7OlibYhmzYAKxefftPovsQIJ5Bd+ffMKCTRupQiIjIhu3btw+zZ8/GkSNHsGvXLlRXV2PkyJEoLy+XLCZRFLHrp12YEzsH7z/7Pla/sBrvP/s+5sTOwa6fdjE5BSbsiIiodZN0Tqny8nL06dMHM2bMwPjx4+us//DDD7F8+XKsXbsWgYGBWLBgAaKionD+/Hk4OjpKEHE95s8Hrl4F2rcHnn5a6mjIBj0lvgG3Ttcx/Vk7LCiVOhoiIrJVaWlpRu9TUlLg7e2NEydOYOjQoRaPRxRFLP9gOfJ/ysdAl4GQO/3vZ6dOrcPPf/8ZmWcykTA/AYIgWDw+qYmiiN1pu7F57WbIimVw1DtCI9NA76lHzLQYRI6KbJXfCxERtS6SJqVGjx6N0aNH17tOFEUsW7YMf/vb3xAdHQ0AWLduHXx8fLB582ZMnszHlBERERE1pLT09v90eHh41Lu+qqoKVVVVhvcqlcqk7e9O2438n/LRT9EPwO3fdiVVJajUVcJJ7oS+rn1xascp7O6zGyNGjTBp29aOCTui5hFFEUqlEiqVCgqFAr6+vjxWiGyU1T59LycnB0qlEpGRkYZlbm5uiIiIwOHDhxtMSpn7BxaRqR0TJkJTdBGnjh0DQqSO5v4VFRWZ9XjLzc2FrkZntvqJiFoSvV6PefPm4eGHH0bPnj3rLbNkyRK89dZbZmlfFEVsXrsZA10GQhRF/Fr0K07nn4az1hmOoiM0ggYV9hXo6d8Tm9dubnVJqT8m7O4kl8nRT9EPJ3ecbJUJO6LGcIQh3Q8mMa2b1SallEolAMDHx8douY+Pj2Fdfcz5A4vIHA4IccgpOo7t//kNT9hoUqqoqAhTp89EibrCbG1oKitwtaAA/bTVZmuDiKilmD17Ns6dO4eDBw82WOb1119HYmKi4b1KpUJAQIBJ2lcqlZAVy2DnaIfdF3ejpqgGg+0GQy67Y0RQtQ6Zv2ci/1Y+rl27Bn9/f5O0be3uTNg1prdLb2xZt4VJKaL/jyMM6V4xiWkbrDYpdb/M+QOLiOqnUqlQoq7AQ49MgKKdz903uA9Xs88h9/sk6HRMShERNWbOnDnYtm0b9u/fjw4dOjRYzsHBAQ4ODmaJQaVSwVHviF+LfkVNUQ16yXvVKSMX5Ogl7wV1sRo7d+zE9JnTzRKLtalN2N15QV0fuUwO4bqAgoIC+Pn5WSg6IuvFEYZ0L5jEtB1Wm5Ty9fUFABQWFhr9Q1xYWIjQ0NAGtzPnDywiapyinQ88fBq+AGqO0uKGR0gSEdHtH+AJCQn44YcfsHfvXgQGBkoWi0KhQKVQicz8TAy2G9xo2SB5EH7Z/kurSUrVJuyawlF0hFqtZlKKWj2OMKR7xSSm7ZBJHUBDAgMD4evri/T0dMMylUqFo0ePYtCgQRJGRkRERGR9Zs+ejX//+9/YsGEDXF1doVQqoVQqUVlZafFYfH19UeZSBqcqJ8iFhv8PVIQImYMMTmonFBQUWDBC6SgUCmhkmiaV1QgauLq6mjkiIutnGGEoa/oIQ2q9apOYvV16N1quNolJ0pI0KVVWVoaMjAxkZGQAuD25eUZGBq5cuQJBEDBv3jy8++672Lp1K86ePYupU6fC398fMTExUoZNZFJ/0U/FP7q+gfSXrkkdChER2bCVK1eitLQUw4YNg5+fn+G1ceNGi8ciCAKGjh2KGl1No+VUOhV8O/gaRgS1Br6+vtB76qHTN/7wDp1eB9Fb5CgpItzfCENqvZjEtC2SJqWOHz+Ovn37om/fvgCAxMRE9O3bFwsXLgQAzJ8/HwkJCXjuuecwYMAAlJWVIS0tDY6OTTshEdkCF9yExwMl8HFt/Ic7ERFRY0RRrPcVFxcnSTyjxoyC3lOPUl0pRIjGsUJEqa4UTt5O8PT2bFUjggRBQMy0GJwpO9NouTPlZxA9NdpCURFZN44wpHvBJKZtkXROqWHDhkEUxQbXC4KAt99+G2+//bYFo7pH/3/uK8OfRPeoDB6oqdai0IxPriMiIrI0Pz8/tO/fHm0vtUXxtWIIWgEyUQa9oIdoL8K3sy88vT1Ro69pdSOCIkdF4vzp8zj500n0dult/FRCvQ5nys8gYHQAIqMiJYySyHoYRhiqdY2OfuEIQwKYxLQ1VjvRuc04flzqCMjGfSFbh5yLx7F9zYd4IkHqaIiIiEyjdkTQz3//Gf369YNGo4GuRge5ndxo1PuZ8jOITmhdI4IEQcDcV+did+hubFm3BcJ1AY6iIzSCBqK3iOiEaERG8VHlRLWMzif1TFxdqzWeT6guJjFtC5NSRERERGQWfxwR5Cj7XzKqtY8IEgQBI0aNwIhRI1BQUAC1Wg1XV1deHBE1gCMMqamYxLQtTEoRERERkVlwRFDT1E5KT0QN4/mE7gWTmLaDSSkiIiIiMhuOCCIiU+H5hJqKSUzbwaRUc/3lL8DNm4CHB/DFF1JHQzZoiJiCAV4X8dCjJciVOhgiIiIz4oggIjIVnk/obpjEtA1MSjXX9u3A1atA+/ZSR0I2Klz8Fm6e1xH2JzssKJU6GiIiIiIiopaFSUzrJZM6ACIiIiIiIiIian04UopIYpuE93H98jns3/oNOvxZ6miIiIiIiIiILINJKSKJ5Qm9kVOhxX9zHdFB6mCIiIiIiIiILIS37xERERERERERkcUxKUVERERERERERBbH2/eIJNZOzIXW/hq6elVLHQoRERERERGRxTApRSSxOHE23B68jmt/scOCUqmjISIiIiIiIrIM3r5HREREREREREQWx5FSzRUbC9y6BbRtK3UkZKPOYiR0Jb/jbMY5IFDqaIiIiIiIiIgsg0mp5lq6VOoIyMb9LJuLnILj2L7tQzyRIHU0RERERERERJbBpBRRK1Gt1SI3N9csdefm5kJXozNL3URERERERNQyMSlF1ApUlpUiJ+d3/PXNxbC3dzB5/ZrKClwtKEA/LZ8gSERERERERE3DpBRRK6DVVEKUyfHg4PHw7tDJ5PVfzT6H3O+ToNMxKUVERERERERNw6RUc3XvDly7Bvj7AxcuSB0N2aBn9XPxQOBVxM0swgYzt+Xq4QUPnw4mr7e0WGnyOomIiIiIiKhlY1KqucrKALX69p9E98Ebv8PN8Trsfe2AUqmjISIiIiIiIrIMJqWIJFYDOar1cmhrpI6EiIiIiIiIyHJkUgdA1Notk23GjKzl6LfE9LfVEREREREREVkrJqWIiIiIiIiIiMjiePseEZGFFBUVQaVSma1+hUIBLy8vs9XfEpi7DwD2AxERERFRUzEpRURkAUVFRZg6fSZK1BVma8Pd1RnrklczIdIAS/QBwH4gIiIiImoqJqWIJBYm/oBuHr/BM0IN847fICmpVCqUqCvw0CMToGjnY/r6bxQie993UKlUTIY0wNx9ALAfiIiIiIjuBZNSRBIbJq6Bm891DB9hhwWlUkdD5qZo5wMPH05qLyX2ARERERGRdeBE50REREREREREZHFWnZRavHgxBEEwenXv3l3qsIytWgVs2nT7T6L78KPwKv6ZPxOJ37WTOhQiIiIiIiIii7H62/dCQkKwe/duw3u53MpCHjtW6gjIxv0mDEGO2gk/Z+7GE5FSR0NERERERERkGVaW4alLLpfD19dX6jCIiIiIiIgsQhRFKJVKlJaWQqPRwNHREW5ubvD19YUgCFKHR1asdt9RqVRQKBTcZ8jAWvcNq09KZWdnw9/fH46Ojhg0aBCWLFmCjh07Nli+qqoKVVVVhvcqlfmfZ1ZUVGS2dnJzc6Gr0ZmlbiIyVq3VIjc31yx1t5Rj2ZznOwBQKBR8ah0RtXrWeuFA5ieKInan7cbmtZtRklWCsmtlqKyuRPkD5fD284ZfNz88EfcEIkdFcp8gI3fuO7JiGRz1jtDINNB76jF07FD06d+Hic1WqrF9I2ZajOTnE6tOSkVERCAlJQXdunVDQUEB3nrrLQwZMgTnzp2Dq6trvdssWbIEb731lsVivLV7N95f9BZuVWqR5aowef2aygpcLShAP221yesm6+AklsDVTo22zjVSh9KqVZaVIifnd/z1zcWwt3cwef0t4VguKirC1OkzUaKuMFsb7q7OWJe8mokpImqVrP3CgcxLFEUs/2A58n7Kg3ehNzyKPKCQKyA8IEAn6pCZl4kKTQV2LtmJzDOZSJifwP2BAPxv38n/KR8DXQZC7iSHCBHF14tx9fxVfJ32NZLbJaNr564QvUSeT1qR+vaNWjq1Dj///WfJzydWnZQaPXq04e+9e/dGREQEOnXqhE2bNiE+Pr7ebV5//XUkJiYa3qtUKgQEBJgtRtcpU/BpYSFuurpj4TtJJq//avY55H6fBJ3Odi9kqXEvilPgFnQd1xLtsKBU6mhaL62mEqJMjgcHj4d3h04mr78lHMsqlQol6go89MgEKNr5mL7+G4XI3vcdVCoVk1JE92nFihVYunQplEol+vTpg3/+858IDw+XOixqAlu4cCDz2p22G/k/5aOjpiOKiorgJnczrJMLcvSS98LZorNwcHNA3o487O6zGyNGjZAwYrIWtftOP0U/AIAIETkXc6C5roGn3BNeDl44W3IWbmVu6O7YneeTVuSP+8ad5DI5+in64eSOk5KeT6w6KfVH7u7uCAoKwsWLFxss4+DgAAcH049yuBtBJoOHTweT11tarDR5nUTUMFcPLx7Ld6Fo52OW74iImmfjxo1ITEzEqlWrEBERgWXLliEqKgpZWVnw9vaWOjy6C1u4cCDzEUURm9duRoRLBC5cvIC28rb1luth1wO/5P+Cp0KfwpZ1W7gvkGHfGegy0LCs+HoxNNc1RonN2n2np3dPnk9aifr2jfr0dukt6flEJkmr96msrAyXLl2Cn5+f1KEQmcwlhOOkuhf2ZjtJHQoREdmwTz75BLNmzcL06dMRHByMVatWwdnZGUlJph/JTaZVe+HQ26V3o+VqLxyo5VEqlZAVy1CjrYGgFSCg/tErckEOJ60T1Fo1hOsCCgoKLBwpWZvafUcuuz3eRIQIZb4SCrnx1DK1+84tzS0APJ+0Bn/cNxoil8klPZ9YdVLqlVdewb59+3D58mUcOnQITzzxBOzs7BAbGyt1aEQms1m2EJ/mv4A5Gz2lDoWIiGyUVqvFiRMnEBkZaVgmk8kQGRmJw4cPSxgZNYWtXDiQ+ahUKjjqHaHT6SATG79EcxQdodFp4Cg6Qq1WWyhCsla1+06tKk1Vg4nN2n0H4PmkNfjjvtEYKc8nVn37Xn5+PmJjY3Hjxg14eXlh8ODBOHLkCOcaISIiIrpDcXExampq4ONjPN+bj48PLly4UO82UjyxmOp3PxcOvHOgZVEoFNDINJALcugFfaNlNYIGjnJHaERNgw9/otajdt+p1Vhis3bfqcXzScv2x32jMRpBuvOJVSelvvnmG6lDICIiImqRLP3EYmqYrVw4kPn4+vpC76mHndoOor0IUSfWO9JFJ+pQaV8JV3tXiG4ikwlk2Hd0ah3kMjnk8voTm7X7TlvH/81XxvNJy/bHfaMhOr0Oord05xOrTkoREVHTVWu1yM3NNVv9ubm50NXozFY/Ed0/T09P2NnZobCw0Gh5YWEhfH19693G0k8spobZyoUDmY8gCIiZFoOf//4zAjoEoOii8dP3amXWZKJ3YG+cKT+D6IRoCSIla3PnvtNP0Q8Ojg71JjZr951aPJ+0fH/cNxoi9fmESSkiiU3QL4AQcAV/froIaVIHQzarsqwUOTm/469vLoa9vXmeQKqprMDVggL001abpX4iun/29vYICwtDeno6YmJiAAB6vR7p6emYM2dOvdtI9cRiqstWLhzIvCJHReL86fO48tMVuHq5orSoFAq5AgIE6EQdMmsyIXgJqHKsQsfRHREZFXn3SqlVqN13Tv50Er1desO3g68hsVm779h52yHEK8SwDc8nrcMf9407/+NDp9fhTPkZBIwOkPR8wqQUkcQ64xTcXK7Ds4sd0kqljoZslVZTCVEmx4ODx8O7QyeztHE1+xxyv0+CTsekFJE1SkxMxLRp09C/f3+Eh4dj2bJlKC8vx/Tp06UOjZrAFi4cyLwEQcDcV+did+hubF67GSUXSqC+poamWoPyB8rhHeAN/x7+iJoWhcioSAhC/U/oo9bnzn1ny7otEKoEFLkXoeRmCeROcvQJ7IMQrxAIgsDzSStTZ9+4Ltye8F7QQPQWEZ0QLfn5hEkpIqIWxNXDCx4+HcxSd2mx0iz1EpFpTJo0CUVFRVi4cCGUSiVCQ0ORlpZWZ/Jzsk62cOFA5icIAkaMGoERo0agoKAAarUaFRUVcHZ2hqurK2+1ogb9cd9RqVQ4deIUDm47CNV1FU5VnuL5pJWq77xiTecTJqWa6crOnZj14jyE/nkW2kgdDNmkfwobkXvhJHau+wdGPCd1NEREZMvmzJnT4O16ZP2s/cKBLMvPz499T/eldt/p1q0bJj89mecTMrDG8wqTUs0kurigQi5HlaMTk1J0X7RCG2j0Tiirqv/RrURERNT6WOOFAxHZJp5PyJrxKpiIiIiIiIiIiCyOSSkiIiIiIiIiIrI43r7XTG5r1iD+8iV47NmKjMkvSh0O2aAe4h74Kc5D6FkudShERNSKiaIIAFCpVBJHQkRERLau9vdE7e+LhjAp1UzuSUmYWViIW6WlTErRfXlc/Bhu7a8jOsYOC0qljoaIiFortVoNAAgICJA4EiIiImop1Go13NzcGlzPpBQRERERwd/fH3l5eXB1dTXLY8JVKhUCAgKQl5cHhUJh8vrJctiXLQv7s+VgX7YcLaEvRVGEWq2Gv79/o+WYlCKSWLrwPNQFWTi2dzcwSOpoiIiotZLJZOjQoYPZ21EoFDb7A5uMsS9bFvZny8G+bDlsvS8bGyFVixOdE0ksQxiL3bcewdfHXaUOhYiIiIiIiMhimJQiIiIiIiIiIiKLY1KKiIiIiMzOwcEBixYtgoODg9ShUDOxL1sW9mfLwb5sOVpTX3JOKSIiIiIyOwcHByxevFjqMMgE2JctC/uz5WBfthytqS+ZlCKS2Mv6sXDrcR3X/maHBaVSR0MkrWqtFrm5uWapOzc3F7oanVnqJiIiIiKie8ekFBERWYXKslLk5PyOv765GPb2ph+qrKmswNWCAvTTVpu8biIiIiIiundMSjVTVUgIMis0QIcuUodCNqoA3XC9og0uXlUCLlJHQyQdraYSokyOBwePh3eHTiav/2r2OeR+nwSdjkkpIiIiIiJrwInOm0n55Zd4ru8AfDHrDalDIRu1QfYx3s79K55J9pE6FCKr4OrhBQ+fDiZ/ubT1lPqjEbVqK1asQOfOneHo6IiIiAgcO3ZM6pDoHi1evBiCIBi9unfvLnVY1AT79+/HuHHj4O/vD0EQsHnzZqP1oihi4cKF8PPzg5OTEyIjI5GdnS1NsHRXd+vPuLi4OsfqqFGjpAmWGrVkyRIMGDAArq6u8Pb2RkxMDLKysozKaDQazJ49G+3atYOLiwsmTJiAwsJCiSI2PSaliIiIiMisNm7ciMTERCxatAgnT55Enz59EBUVhevXr0sdGt2jkJAQFBQUGF4HDx6UOiRqgvLycvTp0wcrVqyod/2HH36I5cuXY9WqVTh69CjatGmDqKgoaDQaC0dKTXG3/gSAUaNGGR2rX3/9tQUjpKbat28fZs+ejSNHjmDXrl2orq7GyJEjUV5ebijzf//3f/jxxx+RmpqKffv24dq1axg/fryEUZsWb98jIiIiIrP65JNPMGvWLEyfPh0AsGrVKmzfvh1JSUl47bXXJI6O7oVcLoevr6/UYdA9Gj16NEaPHl3vOlEUsWzZMvztb39DdHQ0AGDdunXw8fHB5s2bMXnyZEuGSk3QWH/WcnBw4LFqA9LS0ozep6SkwNvbGydOnMDQoUNRWlqKNWvWYMOGDXj00UcBAMnJyejRoweOHDmCgQMHShG2SXGkFBERERGZjVarxYkTJxAZGWlYJpPJEBkZicOHD0sYGd2P7Oxs+Pv7o0uXLnjmmWdw5coVqUOiZsrJyYFSqTQ6Rt3c3BAREcFj1Ibt3bsX3t7e6NatG1544QXcuHFD6pCoCUpLbz+O3cPDAwBw4sQJVFdXGx2f3bt3R8eOHVvM8cmkVDP5Pvccvjz1X/zlX+9LHQrZqMf1S/G8fzL+HsN/KIiIqOUpLi5GTU0NfHyM50708fGBUqmUKCq6HxEREUhJSUFaWhpWrlyJnJwcDBkyBGq1WurQqBlqj0Meoy3HqFGjsG7dOqSnp+ODDz7Avn37MHr0aNTU1EgdGjVCr9dj3rx5ePjhh9GzZ08At49Pe3t7uLu7G5VtSccnb99rJodff0UvdSlu5f8udShko3pgH9zcriOwpx2OlkodDRG1dkVFRVCpVGarX6vVwt7e3mz1A4BCoYCXl5dZ2yBqje68Xah3796IiIhAp06dsGnTJsTHx0sYGRHd6c5bLnv16oXevXvjwQcfxN69e/HYY49JGBk1Zvbs2Th37lyrm6uPSSkiIiICcDshNXX6TJSoK8xSf7VWi/y8XAR0DoTcznw/QdxdnbEueTUTU1bC09MTdnZ2dZ4UVFhYyPlObJy7uzuCgoJw8eJFqUOhZqg9DgsLC+Hn52dYXlhYiNDQUImiIlPq0qULPD09cfHiRSalrNScOXOwbds27N+/Hx06dDAs9/X1hVarRUlJidFoqZb0byiTUkQSWyN8gavZp5G+6V8Ie0bqaIioNVOpVChRV+ChRyZA0c7n7hvco6vZ5/B7bhICB0XDu0Mnk9cPAKobhcje9x1UKhWTUlbC3t4eYWFhSE9PR0xMDIDbtyikp6djzpw50gZHzVJWVoZLly7h2WeflToUaobAwED4+voiPT3dkIRSqVQ4evQoXnjhBWmDI5PIz8/HjRs3jJKOZB1EUURCQgJ++OEH7N27F4GBgUbrw8LC8MADDyA9PR0TJkwAAGRlZeHKlSsYNGiQFCGbHJNSRBIrEdrjenUBrtx8AGFSB0NEBEDRzgcePh3uXvAelRbfnvvA1cPLLPWT9UpMTMS0adPQv39/hIeHY9myZSgvLzc8jY9swyuvvIJx48ahU6dOuHbtGhYtWgQ7OzvExsZKHRrdRVlZmdGItpycHGRkZMDDwwMdO3bEvHnz8O677+Khhx5CYGAgFixYAH9/f0MimaxLY/3p4eGBt956CxMmTICvry8uXbqE+fPno2vXroiKipIwaqrP7NmzsWHDBmzZsgWurq6GeaLc3Nzg5OQENzc3xMfHIzExER4eHlAoFEhISMCgQYNaxJP3ABtJSq1YsQJLly6FUqlEnz598M9//hPh4eFSh0VERERETTBp0iQUFRVh4cKFUCqVCA0NRVpaWp2Jlcm65efnIzY2Fjdu3ICXlxcGDx6MI0eOcFSiDTh+/DiGDx9ueJ+YmAgAmDZtGlJSUjB//nyUl5fjueeeQ0lJCQYPHoy0tDQ4OjpKFTI1orH+XLlyJc6cOYO1a9eipKQE/v7+GDlyJN555x04ODhIFTI1YOXKlQCAYcOGGS1PTk5GXFwcAODTTz+FTCbDhAkTUFVVhaioKHz++ecWjtR8rD4ptXHjRiQmJmLVqlWIiIjAsmXLEBUVhaysLHh7e0sdHhERERE1wZw5c3i7no375ptvpA6B7tOwYcMgimKD6wVBwNtvv423337bglHR/bpbf+7cudOC0VBzNNaPtRwdHbFixQqsWLHCAhFZnkzqAO7mk08+waxZszB9+nQEBwdj1apVcHZ2RlJSktShEZlEZ/EEerU5j4cfrJQ6FCIiIiIiIiKLseqklFarxYkTJxAZGWlYJpPJEBkZicOHD0sYGZHpTBAXYX7Hz/BFbLHUoRARERERERFZjFXfvldcXIyampo68w34+PjgwoUL9W5TVVWFqqoqw/vS0lIAt58gYQ46vR5yAKU1NVDm/mby+m8V5kPU63GzIA92ZkohmrsNW6/f3G2UtK2GIAPUlaLNfke23ges3zrasPX6AUB18zqqKitx/vx5qNVq8zRiRnl5edBWaVB87TK0mgqT12+pPtDpdFCr1Wb5t7+2zqYMtyciIiKixgmiFf+qunbtGtq3b49Dhw4ZPe5w/vz52LdvH44ePVpnm8WLF+Ott96yZJhERETUyuTl5aFDBz5BkIiIiKg5rHqklKenJ+zs7FBYWGi0vLCwEL6+vvVu8/rrrxuePgAAer0eN2/eRLt27SAIgsliU6lUCAgIQF5eHhQKhcnqJfNj39km9pvtYt/ZLvZdXaIoQq1Ww9/fX+pQiIiIiGyeVSel7O3tERYWhvT0dMTExAC4nWRKT09v8OktDg4OdR516e7ubrYYFQoFf6jbKPadbWK/2S72ne1i3xlzc3OTOgQiIiKiFsGqJzoHgMTERPzrX//C2rVrkZmZiRdeeAHl5eWYPn261KERERERERERgC1btiAwMBADBgzAb7+Zfq5dImqZrHqkFABMmjQJRUVFWLhwIZRKJUJDQ5GWllZn8nMiIiIiIiKSRkJCApKSknDq1CksWLAAGzdulDokIrIBVj9SCgDmzJmD3NxcVFVV4ejRo4iIiJA6JDg4OGDRokV1bhUk68e+s03sN9vFvrNd7DsiIvqjNWvWYOTIkXWWt2vXDl27dkWnTp3g4eFhtK64uBje3t7Iz8+3VJhEZCOs+ul7REREREREZB00Gg26dOmC1NRUPPzww0brUlNTMXnyZABAQUEBvL29jda/8soruHXrFtasWWOxeInI+tnESCkiIiIiIiKS1rfffguFQlEnIQUAhw4dQmxsLNq3b4+jR4/WWT99+nSsX78eN2/etESoRGQjmJQiIiIiIiJqRYqKiuDr64v333/fsOzQoUOwt7dHenp6g9t98803GDduXJ3l1dXVWL9+PZ599lk8/fTTSE5OrlMmJCQE/v7++OGHH0zzIYioRWBSioiIiIiIqBXx8vJCUlISFi9ejOPHj0OtVuPZZ5/FnDlz8NhjjzW43cGDB9G/f/86y7dt2wY7OztERkZiypQp2LZtG4qLi+uUCw8Px4EDB0z6WYjItjEp9Qfvvfce/vSnP8HZ2Rnu7u71lpk7dy7CwsLg4OCA0NDQests2rQJoaGhcHZ2RqdOnbB06dI6Zfbu3Yt+/frBwcEBXbt2RUpKiuk+SCtkqr7buXMnBg4cCFdXV3h5eWHChAm4fPmyURn2nemYot8WL14MQRDqvNq0aWNULjU1Fd27d4ejoyN69eqFHTt2mOETtR6mOuZEUcRHH32EoKAgODg4oH379njvvfeMyvCYMy1T9N3ly5frPe6OHDliVI7HHRGRdXr88ccxa9YsPPPMM3j++efRpk0bLFmypMHyJSUlKC0thb+/f511ycnJmDx5Muzs7NCzZ08EBwdj/fr1dcr5+/sjNzfXpJ+DiGwbk1J/oNVq8eSTT+KFF15otNyMGTMwadKketf99NNPhpP7uXPn8Pnnn+PTTz/FZ599ZiiTk5ODMWPGYPjw4cjIyMC8efMwc+ZM7Ny506SfpzUxRd/l5OQgOjoajz76KDIyMrBz504UFxdj/PjxRmXYd6Zjin575ZVXUFBQYPQKDg7Gk08+aShTO89BfHw8Tp06hZiYGMTExODcuXMm/TytiSn6DgBeeuklrF69Gh999BEuXLiArVu3Ijw83LCex5zpmarvAGD37t1Gx15YWJhhHY87IiLr9tFHH0Gn0yE1NRXr169v9GmrlZWVAABHR0ej5YWFhfjpp58wZcoUw7IpU6bUewufk5MTKioqTBQ9EbUIItUrOTlZdHNza7TMokWLxD59+tRZHhsbK06cONFo2fLly8UOHTqIer1eFEVRnD9/vhgSEmJUZtKkSWJUVFSz4qbm9V1qaqool8vFmpoaw7KtW7eKgiCIWq1WFEX2nbk0p9/+KCMjQwQg7t+/37DsqaeeEseMGWNULiIiQvzLX/5yP+HSHZrTd+fPnxflcrl44cKFBrflMWc+zem7nJwcEYB46tSpBrflcUdEZN3Onj0rOjo6inZ2duLWrVsbLVtVVSUKgiDu3LnTaPnSpUtFAKKdnZ3hJZPJRADiyZMnjco+//zzdf5dIKLWjSOlzKCqqqrO/yA4OTkhPz/fMFz18OHDiIyMNCoTFRWFw4cPWyxOqissLAwymQzJycmoqalBaWkpvvrqK0RGRuKBBx4AwL6zBatXr0ZQUBCGDBliWMZ+s04//vgjunTpgm3btiEwMBCdO3fGzJkzjZ7Mw76zbn/+85/h7e2NwYMHY+vWrUbr2HdERNZLq9ViypQpmDRpEt555x3MnDkT169fb7C8vb09goODcf78eaPlycnJePnll5GRkWF4nT59GsOHD69zu/25c+fQt29fc3wcIrJRTEqZQVRUFL7//nukp6dDr9fjt99+w8cffwwAKCgoAAAolUr4+PgYbefj4wOVSmUYGkuWFxgYiJ9//hlvvPEGHBwc4O7ujvz8fGzatMlQhn1n3TQaDdavX4/4+Hij5Q31m1KptGR49Ae///47cnNzkZqainXr1iElJQUnTpzAxIkTDWV4zFknFxcXfPzxx0hNTcX27dsxePBgxMTEGCWmeNwREVmvN998E6WlpVi+fDleffVVBAUFYcaMGY1uExUVhYMHDxreHzt2DOfPn8fMmTPRs2dPo1dsbCzWr18PrVYLAKioqMCJEycwcuRIs34uIrItrSIp9dprr9U7GeudrwsXLpisvVmzZmHOnDkYO3Ys7O3tMXDgQEyePBkAIJO1iq/cZCzdd0qlErNmzcK0adPw3//+F/v27YO9vT0mTpwIURRN1k5LZ+l+u9MPP/wAtVqNadOmmaX+ls7SfafX61FVVYV169ZhyJAhGDZsGNasWYM9e/YgKyvLZO20BpbuO09PTyQmJiIiIgIDBgzA3//+d0yZMqXeB3sQEZF12bt3L5YtW4avvvoKCoUCMpkMX331FQ4cOICVK1c2uF18fDx27NiB0tJSALdHSQUHB6N79+51ysbExKCkpAQ//vgjAGDLli3o2LGj0Uh2IiK51AFYwssvv4y4uLhGy3Tp0sVk7QmCgA8++ADvv/8+lEolvLy8kJ6ebtSOr68vCgsLjbYrLCyEQqGAk5OTyWKxdZbuuxUrVsDNzQ0ffvihYdm///1vBAQE4OjRoxg4cCD7rgks3W93Wr16NcaOHVtndEZD/ebr62uWOGyVpfvOz88PcrkcQUFBhmU9evQAAFy5cgXdunXjMddEUh53tSIiIrBr1y7Dex53RETWadiwYaiurjZa1rlzZ0OyqSHBwcEYM2YMPv/8c7z++uuNJrC8vLyg0+kM7//xj39g4cKFzQuciFqcVpGU8vLygpeXl8XbtbOzQ/v27QEAX3/9NQYNGmSIY9CgQXUei71r1y4MGjTI4nFaM0v3XUVFRZ3RbHZ2dgBuj+gA2HdNIdUxl5OTgz179tSZ1wa43W/p6emYN2+eYRn7rS5L993DDz8MnU6HS5cu4cEHHwQA/PbbbwCATp06AeAx11RSHXd3ysjIgJ+fn+E9jzsiopZn6dKlhtFPTVX7NOvY2FgzRUVEtqpVJKXuxZUrV3Dz5k1cuXIFNTU1yMjIAAB07doVLi4uAICLFy+irKwMSqUSlZWVhjLBwcGwt7dHcXExvv32WwwbNgwajQbJyclITU3Fvn37DO08//zz+OyzzzB//nzMmDED//nPf7Bp0yZs377d0h+5xTBF340ZMwaffvop3n77bcTGxkKtVuONN95Ap06dDJMysu9MyxT9VispKQl+fn4YPXp0nXZeeuklPPLII/j4448xZswYfPPNNzh+/Di+/PJLs3/GlsoUfRcZGYl+/fphxowZWLZsGfR6PWbPno0RI0YYRk/xmDM9U/Td2rVrYW9vbzg3fv/990hKSsLq1asN7fC4IyJqeTp37oyEhIR72sbT0xPz5883U0REZNOkfvyftZk2bZoIoM5rz549hjKPPPJIvWVycnJEURTFoqIiceDAgWKbNm1EZ2dn8bHHHhOPHDlSp609e/aIoaGhor29vdilSxcxOTnZMh+yhTJF34miKH799ddi3759xTZt2oheXl7in//8ZzEzM9OoLfad6Ziq32pqasQOHTqIb7zxRoNtbdq0SQwKChLt7e3FkJAQcfv27Wb8ZC2fqfru6tWr4vjx40UXFxfRx8dHjIuLE2/cuGHUFo850zJF36WkpIg9evQQnZ2dRYVCIYaHh4upqal12uJxR0REREQNEUSRszcTEREREREREZFl8VFwRERERERERERkcUxKERERERERERGRxTEpRUREREREREREFsekFBERERERERERWRyTUkREREREREREZHFMShERERERERERkcUxKUVERERERERERBbHpBQREREREREREVkck1JEZHLDhg3DvHnzzN5O586dsWzZMrO3Ywu0Wi26du2KQ4cOmbTe4uJieHt7Iz8/36T1EhERERERMSlF1IoolUokJCSgS5cucHBwQEBAAMaNG4f09HSpQ7OYxYsXQxCEOq/u3btLHVqzrFq1CoGBgfjTn/7UpPIJCQno0aNHveuuXLkCOzs7bN26FZ6enpg6dSoWLVpkynCJiIiIiIiYlCJqLS5fvoywsDD85z//wdKlS3H27FmkpaVh+PDhmD17ttThWVRISAgKCgqMXgcPHjRrm1qt1mx1i6KIzz77DPHx8U3eJj4+HhcuXKh3ZFVKSgq8vb3x+OOPAwCmT5+O9evX4+bNmyaLmYiIiIiIiEkpolbixRdfhCAIOHbsGCZMmICgoCCEhIQgMTERR44cMZS7cuUKoqOj4eLiAoVCgaeeegqFhYWG9XFxcYiJiTGqe968eRg2bFiDbd+6dQtTp05F27Zt4ezsjNGjRyM7O9uwPiUlBe7u7ti2bRu6desGZ2dnTJw4ERUVFVi7di06d+6Mtm3bYu7cuaipqTGqW61WIzY2Fm3atEH79u2xYsWKu34Xcrkcvr6+Ri9PT0/D+s6dO+P999/HjBkz4Orqio4dO+LLL780qiMvLw9PPfUU3N3d4eHhgejoaFy+fLnO9/Tee+/B398f3bp1AwAcOnQIoaGhcHR0RP/+/bF582YIgoCMjAyIooiuXbvio48+MmorIyMDgiDg4sWL9X6eEydO4NKlSxgzZkyTYwwNDUW/fv2QlJRktI0oikhJScG0adMgl8sB3E7i+fv744cffrjrd0tERERERNRUTEoRtQI3b95EWloaZs+ejTZt2tRZ7+7uDgDQ6/WIjo7GzZs3sW/fPuzatQu///47Jk2a1Kz24+LicPz4cWzduhWHDx+GKIp4/PHHUV1dbShTUVGB5cuX45tvvkFaWhr27t2LJ554Ajt27MCOHTvw1Vdf4YsvvsC3335rVPfSpUvRp08fnDp1Cq+99hpeeukl7Nq1q1nxAsDHH3+M/v3749SpU3jxxRfxwgsvICsrCwBQXV2NqKgouLq64sCBA/jll1/g4uKCUaNGGY2ISk9PR1ZWFnbt2oVt27ZBpVJh3Lhx6NWrF06ePIl33nkHr776qqG8IAiYMWMGkpOTjWJJTk7G0KFD0bVr13pjPXDgAIKCguDq6mpY1pQY4+PjsWnTJpSXlxu227t3L3JycjBjxgyjNsLDw3HgwIH7/DaJiIiIiIjqYlKKqBW4ePEiRFG867xJ6enpOHv2LDZs2ICwsDBERERg3bp12LdvH/773//eV9vZ2dnYunUrVq9ejSFDhqBPnz5Yv349rl69is2bNxvKVVdXY+XKlejbty+GDh2KiRMn4uDBg1izZg2Cg4MxduxYDB8+HHv27DGq/+GHH8Zrr72GoKAgJCQkYOLEifj0008bjens2bNwcXExej3//PNGZR5//HG8+OKL6Nq1K1599VV4enoa2t64cSP0ej1Wr16NXr16oUePHkhOTsaVK1ewd+9eQx1t2rTB6tWrERISgpCQEGzYsAGCIOBf//oXgoODMXr0aPz1r381ajcuLg5ZWVk4duyY4XvZsGFDnSTRnXJzc+Hv72+0rCkxPv3006iurkZqaqphu+TkZAwePBhBQUFG9fn7+yM3N7fR75WIiIiIiOheyKUOgIjMTxTFJpXLzMxEQEAAAgICDMuCg4Ph7u6OzMxMDBgw4J7bzszMhFwuR0REhGFZu3bt0K1bN2RmZhqWOTs748EHHzS89/HxQefOneHi4mK07Pr160b1Dxo0qM77uz2Rr1u3bti6davRMoVCYfS+d+/ehr8LggBfX19D26dPn8bFixeNRiYBgEajwaVLlwzve/XqBXt7e8P7rKws9O7dG46OjoZl4eHhRnX4+/tjzJgxSEpKQnh4OH788UdUVVXhySefbPDzVFZWGtXZ1Bjd3d0xfvx4JCUlIS4uDiqVCt999129t0A6OTmhoqKiwRiIiIiIiIjuFZNSRK3AQw89BEEQcOHChWbXJZPJ6iS57rwN73498MADRu8FQah3mV6vb3Zb9vb2Dd4K11g8tW2XlZUhLCwM69evr7Odl5eX4e/13SrZFDNnzsSzzz6LTz/9FMnJyZg0aRKcnZ0bLO/p6YmzZ88aLWtqjPHx8Xjsscdw8eJF7NmzB3Z2dvUmwG7evGm0HRERERERUXPx9j2iVsDDwwNRUVFYsWKF0fxBtUpKSgAAPXr0QF5eHvLy8gzrzp8/j5KSEgQHBwO4ndAoKCgw2j4jI6PBtnv06AGdToejR48alt24cQNZWVmGOpvjzknaa9/36NGj2fU2pl+/fsjOzoa3tze6du1q9HJzc2twu27duuHs2bOoqqoyLKvvtsjHH38cbdq0wcqVK5GWltborXsA0LdvX1y4cMEoWdjUGIcPH47AwEAkJycjOTkZkydPrjeZdu7cOfTt27fROIiIiIiIiO4Fk1JErcSKFStQU1OD8PBwfPfdd8jOzkZmZiaWL19uuAUuMjISvXr1wjPPPIOTJ0/i2LFjmDp1Kh555BH0798fAPDoo4/i+PHjWLduHbKzs7Fo0SKcO3euwXYfeughREdHY9asWTh48CBOnz6NKVOmoH379oiOjm725/rll1/w4Ycf4rfffsOKFSuQmpqKl156qdFtdDodlEql0evOJwzezTPPPANPT09ER0fjwIEDyMnJwd69ezF37lzk5+c3uN3TTz8NvV6P5557DpmZmdi5c6fhSXuCIBjK2dnZIS4uDq+//joeeuihOrco/tHw4cNRVlaGX3/99Z5jrJ1cfeXKlTh8+DDi4+Pr1F9RUYETJ05g5MiRTf6OiIiIiIiI7oZJKaJWokuXLjh58iSGDx+Ol19+GT179sSIESOQnp6OlStXAridoNiyZQvatm2LoUOHIjIyEl26dMHGjRsN9URFRWHBggWYP38+BgwYALVajalTpzbadnJyMsLCwjB27FgMGjQIoihix44ddW6Rux8vv/wyjh8/jr59++Ldd9/FJ598gqioqEa3+fXXX+Hn52f06tSpU5PbdHZ2xv79+9GxY0eMHz8ePXr0QHx8PDQaTZ25qe6kUCjw448/IiMjA6GhoXjzzTexcOFCAKgzJ1R8fDy0Wi2mT59+13jatWuHJ554wuhWvXuJMS4uDqWlpQgJCTGa+6vWli1b0LFjRwwZMuSusRARERERETWVIDZ1BmQiIjK59evXY/r06SgtLYWTk5Nh+YEDB/DYY48hLy8PPj4+d63nzJkzGDFiBC5dumQ0ObwpDBw4EHPnzsXTTz9t0nqJiIiIiKh140TnREQWtG7dOnTp0gXt27fH6dOn8eqrr+Kpp54yJKSqqqpQVFSExYsX48knn2xSQgq4/bTADz74ADk5OejVq5fJ4i0uLsb48eMRGxtrsjqJiIiIiIgAjpQiIrKoDz/8EJ9//jmUSiX8/PwQExOD9957z/B0vZSUFMTHxyM0NBRbt25F+/btJY6YiIiIiIjIPJiUIiIiIiIiIiIii+NE50REREREREREZHFMShERERERERERkcUxKUVERERERERERBbHpBQREREREREREVkck1JERERERERERGRxTEoREREREREREZHFMSlFREREREREREQWx6QUERERERERERFZHJNSRERERERERERkcf8PXB0Iy1MozA8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Read the summary file — all energies from many random configurations\n",
+    "energies = []\n",
+    "filenames = []\n",
+    "summary_file = output_dir / 'li_in_cl_optimized-summary.txt'\n",
+    "with open(summary_file, 'r') as f:\n",
+    "    lines = f.readlines()[1:]  # Skip header\n",
+    "    for line in lines:\n",
+    "        parts = line.strip().split()\n",
+    "        if len(parts) >= 2 and parts[0] != 'NaN':\n",
+    "            filenames.append(parts[0])\n",
+    "            try:\n",
+    "                energies.append(float(parts[1]))\n",
+    "            except ValueError:\n",
+    "                pass\n",
+    "\n",
+    "if energies:\n",
+    "    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))\n",
+    "\n",
+    "    # Panel 1: Energy histogram — now with many bins for a meaningful distribution\n",
+    "    ax1.hist(energies, bins=20, edgecolor='black', alpha=0.7, color='steelblue')\n",
+    "    ax1.set_xlabel('Coulomb Energy (eV)')\n",
+    "    ax1.set_ylabel('Count')\n",
+    "    ax1.set_title(f'Energy Distribution (2×1×1 supercell)\\n{len(energies)} random configurations')\n",
+    "    ax1.axvline(min(energies), color='red', linestyle='--', linewidth=2,\n",
+    "                label=f'Best: {min(energies):.2f} eV')\n",
+    "    ax1.axvline(np.mean(energies), color='orange', linestyle=':', linewidth=2,\n",
+    "                label=f'Mean: {np.mean(energies):.2f} eV')\n",
+    "    ax1.legend()\n",
+    "\n",
+    "    # Panel 2: Li sites in best structure (top view)\n",
+    "    ax2.axis('on')\n",
+    "    li_sites = [s for s in best_structure.sites if s.species.elements[0].symbol == 'Li']\n",
+    "    if li_sites:\n",
+    "        coords = np.array([s.coords[:2] for s in li_sites])\n",
+    "        ax2.scatter(coords[:, 0], coords[:, 1], c='purple', s=60, alpha=0.7,\n",
+    "                   edgecolors='black', linewidth=0.5)\n",
+    "    ax2.set_xlabel('x (Å)')\n",
+    "    ax2.set_ylabel('y (Å)')\n",
+    "    ax2.set_title(f'Li Sites in Best Configuration\\n{len(li_sites)} Li atoms')\n",
+    "    ax2.set_aspect('equal')\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**▲ Figure 1 — Energy landscape + Li positions.** *Left:* histogram of Coulomb energies from 200 random Li configurations in a 2×1×1 supercell. The spread (~45 eV) shows that Li ordering strongly affects the electrostatic energy. The red dashed line marks the lowest-energy configuration found. *Right:* Li atoms (purple dots) of the best structure projected onto the xy-plane."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          0,
+          23.983299000705614
+         ],
+         "y": [
+          0,
+          0
+         ],
+         "z": [
+          0,
+          -8.63877654230511
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          0,
+          1.762063478927751e-15
+         ],
+         "y": [
+          0,
+          10.95727045
+         ],
+         "z": [
+          0,
+          6.709393091992189e-16
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          0,
+          0
+         ],
+         "y": [
+          0,
+          0
+         ],
+         "z": [
+          0,
+          12.61809879
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          23.983299000705614,
+          23.983299000705614
+         ],
+         "y": [
+          0,
+          10.95727045
+         ],
+         "z": [
+          -8.63877654230511,
+          -8.63877654230511
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          23.983299000705614,
+          23.983299000705614
+         ],
+         "y": [
+          0,
+          0
+         ],
+         "z": [
+          -8.63877654230511,
+          3.97932224769489
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          1.762063478927751e-15,
+          23.983299000705614
+         ],
+         "y": [
+          10.95727045,
+          10.95727045
+         ],
+         "z": [
+          6.709393091992189e-16,
+          -8.63877654230511
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          1.762063478927751e-15,
+          1.762063478927751e-15
+         ],
+         "y": [
+          10.95727045,
+          10.95727045
+         ],
+         "z": [
+          6.709393091992189e-16,
+          12.61809879
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          0,
+          23.983299000705614
+         ],
+         "y": [
+          0,
+          0
+         ],
+         "z": [
+          12.61809879,
+          3.97932224769489
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          0,
+          1.762063478927751e-15
+         ],
+         "y": [
+          0,
+          10.95727045
+         ],
+         "z": [
+          12.61809879,
+          12.61809879
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          23.983299000705614,
+          23.983299000705614
+         ],
+         "y": [
+          10.95727045,
+          10.95727045
+         ],
+         "z": [
+          -8.63877654230511,
+          3.97932224769489
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          23.983299000705614,
+          23.983299000705614
+         ],
+         "y": [
+          0,
+          10.95727045
+         ],
+         "z": [
+          3.97932224769489,
+          3.97932224769489
+         ]
+        },
+        {
+         "line": {
+          "color": "gray",
+          "width": 2
+         },
+         "mode": "lines",
+         "showlegend": false,
+         "type": "scatter3d",
+         "x": [
+          1.762063478927751e-15,
+          23.983299000705614
+         ],
+         "y": [
+          10.95727045,
+          10.95727045
+         ],
+         "z": [
+          12.61809879,
+          3.97932224769489
+         ]
+        },
+        {
+         "marker": {
+          "color": "#cc33cc",
+          "line": {
+           "color": "black",
+           "width": 0.5
+          },
+          "opacity": 0.85,
+          "size": 8
+         },
+         "mode": "markers",
+         "name": "Li",
+         "showlegend": true,
+         "type": "scatter3d",
+         "x": [
+          8.982860699167786,
+          20.97451019952059,
+          6.040330797965005,
+          18.03198029831781,
+          8.965018084043221,
+          20.956667584396026,
+          6.132513965336075,
+          18.12416346568888,
+          3.030563957846734,
+          15.022213458199541,
+          0.021324030807508866,
+          12.012973531160315,
+          3.282993216321949,
+          15.274642716674755,
+          9.0570810950863,
+          12.036131085176429,
+          0.004991644021017168,
+          12.010856525357523,
+          21.060528939549513,
+          15.261662955255575,
+          8.886261007285732,
+          20.806199244461478,
+          15.088498499977689,
+          18.098107290155546,
+          3.146640726680249,
+          6.103573798097904,
+          3.088461800131346,
+          2.9901103680902827,
+          14.981759868443088,
+          0.020452237888832017,
+          12.012101978074629,
+          0.10507011342312245,
+          12.096719613775932,
+          5.99093863267099,
+          17.982588372856785
+         ],
+         "y": [
+          3.802979958691347,
+          3.802979958691347,
+          9.307760217139386,
+          9.307760217139386,
+          0.071750836651508,
+          0.071750836651508,
+          7.419050250183071,
+          7.419050250183071,
+          7.304846966666666,
+          7.304846966666666,
+          9.281920453246084,
+          9.281920453246084,
+          0.028330022748475,
+          0.028330022748475,
+          3.845969932720286,
+          9.164970437697509,
+          1.9217099783705809,
+          5.539710064333959,
+          7.295070159486479,
+          3.797940052575165,
+          0.0628433427845895,
+          7.2909197645854285,
+          0.0570298533746375,
+          1.7701899936976637,
+          7.309589857705183,
+          5.563710212091412,
+          1.8798700794480738,
+          3.798389958099842,
+          3.798389958099842,
+          1.8212699396452467,
+          1.8212699396452467,
+          7.328509776591199,
+          7.328509776591199,
+          3.59494993355394,
+          3.59494993355394
+         ],
+         "z": [
+          6.39210295452429,
+          2.0727146833717356,
+          1.0924615652728908,
+          -3.2269267058796625,
+          0.0975128930484419,
+          -4.221875378104112,
+          10.315151284529096,
+          5.995763013376541,
+          2.2186477274391843,
+          -2.1007405437133695,
+          9.512926611488542,
+          5.193538340335988,
+          8.257146230415401,
+          3.9377579592628464,
+          -0.1350575408919843,
+          -1.167284777432061,
+          3.1953236439194592,
+          5.236880533327244,
+          -4.411067296084026,
+          4.05852217143431,
+          6.385806662679046,
+          2.076899983777669,
+          -2.1722018946588295,
+          -3.220187493843214,
+          8.350147614842609,
+          1.0264536171611849,
+          -1.0327965557926708,
+          2.2011199158722703,
+          -2.118268355280284,
+          9.500592248788758,
+          5.181203891248438,
+          6.280059691491171,
+          1.960671420338616,
+          4.4275979708156505,
+          0.10820961327533052
+         ]
+        },
+        {
+         "marker": {
+          "color": "#3366cc",
+          "line": {
+           "color": "black",
+           "width": 0.5
+          },
+          "opacity": 0.85,
+          "size": 14
+         },
+         "mode": "markers",
+         "name": "In",
+         "showlegend": true,
+         "type": "scatter3d",
+         "x": [
+          11.981284398190683,
+          23.972933898543488,
+          3.018304894562523,
+          15.00995439491533,
+          6.12247767420325,
+          18.114127174556057,
+          9.114621106549821,
+          21.10627060690263,
+          0.09168983091062764,
+          12.083339091430444,
+          3.085221896269341,
+          15.076871396622149,
+          6.058539158399331,
+          18.050188658752134,
+          9.051106615472234,
+          21.04275587599205
+         ],
+         "y": [
+          0.0250293641708215,
+          0.0250293641708215,
+          5.6016597321406465,
+          5.6016597321406465,
+          0.120265028150519,
+          0.120265028150519,
+          5.512259910402619,
+          5.512259910402619,
+          0.132662960519285,
+          0.132662960519285,
+          5.541210224231269,
+          5.541210224231269,
+          10.920100211025169,
+          10.920100211025169,
+          5.543700263941031,
+          5.543700263941031
+         ],
+         "z": [
+          -4.25140769582141,
+          -8.570795966973964,
+          -1.007494515853083,
+          -5.326882787005638,
+          10.385197236591429,
+          6.065808965438874,
+          -3.2167109866953902,
+          -7.536099257847946,
+          6.353244755073283,
+          2.033856570308494,
+          5.298752261706778,
+          0.9793639905542229,
+          4.345830760399679,
+          0.02644248924712489,
+          3.1398194550097704,
+          -1.1795687297550197
+         ]
+        },
+        {
+         "marker": {
+          "color": "#cc9933",
+          "line": {
+           "color": "black",
+           "width": 0.5
+          },
+          "opacity": 0.85,
+          "size": 12
+         },
+         "mode": "markers",
+         "name": "Cl",
+         "showlegend": true,
+         "type": "scatter3d",
+         "x": [
+          1.5791141287962194,
+          13.570763868982016,
+          4.582346239435768,
+          16.573995739788575,
+          10.621433743180575,
+          22.61308324353338,
+          1.5992121333588116,
+          13.590861633711619,
+          10.610421811444402,
+          22.602071311797207,
+          1.6579280459723387,
+          13.649577306492155,
+          1.5290125375177668,
+          13.520662037870576,
+          4.462653268778927,
+          16.454302769131733,
+          1.5164594389878057,
+          13.508108939340614,
+          4.50115533749569,
+          16.492804837848496,
+          10.656213364059438,
+          22.647862864412243,
+          1.7021681189750206,
+          13.69381761932783,
+          7.505300732161183,
+          19.496950232513992,
+          10.41632401329973,
+          22.407973513652536,
+          4.447858211458381,
+          16.439507471978196,
+          7.63088208238868,
+          19.622531582741487,
+          4.592106003131117,
+          16.583755263650932,
+          7.728219740380983,
+          19.71986924073379,
+          7.452494304421433,
+          19.444143804774235,
+          10.48195694917805,
+          22.47360644953086,
+          7.58163813388249,
+          19.573287634235296,
+          10.488051824953102,
+          22.479701325305907,
+          4.617253931131295,
+          16.6089034314841,
+          7.527198443480789,
+          19.518847943833595,
+          1.5564547079003528,
+          13.548104208253159,
+          4.38491596189495,
+          16.376565462247754,
+          10.5618213348504,
+          22.553470835203207,
+          1.573454310065044,
+          13.56510381041785,
+          10.643499097760195,
+          22.63514835828001,
+          1.6974949731647326,
+          13.68914471335053,
+          1.480452832532068,
+          13.472102332884877,
+          4.494148137026653,
+          16.48579763737946,
+          1.4164828986064544,
+          13.408132398959262,
+          4.562043177666721,
+          16.553692678019527,
+          10.671916908746129,
+          22.663566409098934,
+          1.5620262680912074,
+          13.553675768444014,
+          7.520754131039299,
+          19.512403631392107,
+          10.59201582862631,
+          22.583665328979116,
+          4.653758670707278,
+          16.645408171060087,
+          7.622543808825104,
+          19.61419330917791,
+          4.568245258788305,
+          16.55989475914111,
+          7.558264250509393,
+          19.549913990695188,
+          7.6725780070333665,
+          19.664227507386173,
+          10.499219887965769,
+          22.490869148485586,
+          7.435166370893421,
+          19.426815871246227,
+          10.490512751263564,
+          22.48216225161637,
+          4.491049015129781,
+          16.48269851548259,
+          7.578451712777257,
+          19.570101213130062
+         ],
+         "y": [
+          1.8088199602418433,
+          1.8088199602418433,
+          7.309430100702022,
+          7.309430100702022,
+          1.7811299516603527,
+          1.7811299516603527,
+          7.281809780360594,
+          7.281809780360594,
+          9.26599022560235,
+          9.26599022560235,
+          3.741559965338212,
+          3.741559965338212,
+          9.308019685303643,
+          9.308019685303643,
+          3.7513799806882067,
+          3.7513799806882067,
+          0.10054402322190449,
+          0.10054402322190449,
+          5.592989901469789,
+          5.592989901469789,
+          0.06999767337950799,
+          0.06999767337950799,
+          5.595349768806606,
+          5.595349768806606,
+          1.7933399668409011,
+          1.7933399668409011,
+          7.299650188961874,
+          7.299650188961874,
+          1.8138600855034344,
+          1.8138600855034344,
+          7.317409952052644,
+          7.317409952052644,
+          9.255649520760572,
+          9.255649520760572,
+          3.802279898682296,
+          3.802279898682296,
+          9.23093035691619,
+          9.23093035691619,
+          3.7848799723531052,
+          3.7848799723531052,
+          0.08679757957885699,
+          0.08679757957885699,
+          5.634339791257771,
+          5.634339791257771,
+          0.129681048939022,
+          0.129681048939022,
+          5.587600239280842,
+          5.587600239280842,
+          1.7790900366206763,
+          1.7790900366206763,
+          7.295400192472433,
+          7.295400192472433,
+          1.787679988789954,
+          1.787679988789954,
+          7.333879934838743,
+          7.333879934838743,
+          9.217670416081123,
+          9.217670416081123,
+          3.821520098583565,
+          3.821520098583565,
+          9.219780019360861,
+          9.219780019360861,
+          3.76097011250416,
+          3.76097011250416,
+          0.08419533741968649,
+          0.08419533741968649,
+          5.512139818718487,
+          5.512139818718487,
+          0.058329714368121,
+          0.058329714368121,
+          5.542860060442925,
+          5.542860060442925,
+          1.853250048326026,
+          1.853250048326026,
+          7.309549754095336,
+          7.309549754095336,
+          1.8688900178755377,
+          1.8688900178755377,
+          7.274220007837993,
+          7.274220007837993,
+          9.280019805113826,
+          9.280019805113826,
+          3.787709906592227,
+          3.787709906592227,
+          9.289730028613912,
+          9.289730028613912,
+          3.825509969472523,
+          3.825509969472523,
+          0.031130043639268,
+          0.031130043639268,
+          5.569059880243215,
+          5.569059880243215,
+          0.064753304596729,
+          0.064753304596729,
+          5.5052899906693735,
+          5.5052899906693735
+         ],
+         "z": [
+          1.0978746438464195,
+          -3.2215137136939003,
+          0.0601895826315999,
+          -4.2591986885209545,
+          7.207641198305156,
+          2.8882529271526014,
+          10.427150360209172,
+          6.107762089056617,
+          7.200234495391176,
+          2.8808462242386206,
+          10.484548067722098,
+          6.165159882957309,
+          1.1673759349696273,
+          -3.1520123361829278,
+          0.04670383891826657,
+          -4.272684432234288,
+          10.631803189638418,
+          6.312414918485863,
+          9.585202429000836,
+          5.265814157848281,
+          -2.1551230987008108,
+          -6.4745113698533645,
+          1.0474815832316158,
+          -3.2719066879209393,
+          -0.9109741652966472,
+          -5.230362436449202,
+          -2.0373702867676577,
+          -6.356758557920212,
+          9.522557533635943,
+          5.203169348871154,
+          8.469355561763466,
+          4.1499672906109115,
+          9.535011260808785,
+          5.215623076043997,
+          8.380086333171173,
+          4.060698062018619,
+          -0.9476596896438918,
+          -5.267047960796446,
+          -2.00122341626839,
+          -6.3206116874209455,
+          8.513558668850841,
+          4.194170397698286,
+          7.241548887488957,
+          2.9221606163364022,
+          -0.06356285596935529,
+          -4.38295112712191,
+          -1.0436986218477224,
+          -5.363086893000277,
+          7.5157344722840005,
+          3.1963462011314467,
+          6.3408375091080575,
+          2.021449237955503,
+          0.934686909647946,
+          -3.384701361504609,
+          4.24780139098305,
+          -0.07158688016950343,
+          0.9659788405577676,
+          -3.353409344207022,
+          4.188305434115128,
+          -0.13108292342519245,
+          7.45481542928669,
+          3.135427158134135,
+          6.315958008135171,
+          1.9965697369826163,
+          4.244288998863497,
+          -0.07509927228905777,
+          3.1405740756563767,
+          -1.1788141954961784,
+          4.089558375636666,
+          -0.22982989551588862,
+          7.414644355899947,
+          3.0952560847473913,
+          5.184025121358429,
+          0.8646368502058746,
+          4.139065460285082,
+          -0.18032281086747481,
+          3.0788081617759238,
+          -1.2405801093766318,
+          2.005540978516995,
+          -2.3138472926355593,
+          3.017627027072196,
+          -1.3017612440803585,
+          2.0238477167039237,
+          -2.295540640836397,
+          5.249859728565732,
+          0.9304714574131783,
+          4.269830327590501,
+          -0.049557857174288955,
+          2.1441421787901906,
+          -2.1752460923623644,
+          1.0993772524523728,
+          -3.2200110187001822,
+          6.157746460685552,
+          1.8383581895329977,
+          5.152167187228599,
+          0.8327789160760446
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "scene": {
+         "aspectmode": "cube",
+         "camera": {
+          "eye": {
+           "x": 1.5,
+           "y": 1.5,
+           "z": 1.5
+          }
+         },
+         "xaxis": {
+          "title": {
+           "text": "x (Å)"
+          }
+         },
+         "yaxis": {
+          "title": {
+           "text": "y (Å)"
+          }
+         },
+         "zaxis": {
+          "title": {
+           "text": "z (Å)"
+          }
+         }
+        },
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "<b>GOAC Optimized Structure — 147 atoms</b>"
+        },
+        "width": 800
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 3D interactive plot of the GOAC-optimized structure\n",
+    "import plotly.graph_objects as go\n",
+    "import numpy as np\n",
+    "\n",
+    "if best_cif.exists():\n",
+    "    fig = go.Figure()\n",
+    "\n",
+    "    # Lattice frame\n",
+    "    lattice = best_structure.lattice\n",
+    "    origin = lattice.get_cartesian_coords([0, 0, 0])\n",
+    "    a = lattice.get_cartesian_coords([1, 0, 0])\n",
+    "    b = lattice.get_cartesian_coords([0, 1, 0])\n",
+    "    c = lattice.get_cartesian_coords([0, 0, 1])\n",
+    "\n",
+    "    edges = [\n",
+    "        (origin, a), (origin, b), (origin, c),\n",
+    "        (a, a + b), (a, a + c),\n",
+    "        (b, a + b), (b, b + c),\n",
+    "        (c, a + c), (c, b + c),\n",
+    "        (a + b, a + b + c), (a + c, a + b + c), (b + c, a + b + c),\n",
+    "    ]\n",
+    "    for start, stop in edges:\n",
+    "        fig.add_trace(go.Scatter3d(\n",
+    "            x=[start[0], stop[0]], y=[start[1], stop[1]], z=[start[2], stop[2]],\n",
+    "            mode='lines', line={'color': 'gray', 'width': 2}, showlegend=False,\n",
+    "        ))\n",
+    "\n",
+    "    # Atom sites colored by element — only one trace per element\n",
+    "    element_styles = {\n",
+    "        'Li': {'color': '#cc33cc', 'size': 8, 'label': 'Li'},\n",
+    "        'In': {'color': '#3366cc', 'size': 14, 'label': 'In'},\n",
+    "        'Cl': {'color': '#cc9933', 'size': 12, 'label': 'Cl'},\n",
+    "    }\n",
+    "\n",
+    "    for elem, style in element_styles.items():\n",
+    "        elem_coords = [s.coords for s in best_structure.sites\n",
+    "                       if s.species.elements[0].symbol == elem]\n",
+    "        if not elem_coords:\n",
+    "            continue\n",
+    "        xs, ys, zs = zip(*elem_coords)\n",
+    "        fig.add_trace(go.Scatter3d(\n",
+    "            x=xs, y=ys, z=zs,\n",
+    "            mode='markers',\n",
+    "            marker={'size': style['size'], 'color': style['color'],\n",
+    "                    'opacity': 0.85, 'line': {'width': 0.5, 'color': 'black'}},\n",
+    "            name=style['label'], showlegend=True,\n",
+    "        ))\n",
+    "\n",
+    "    fig.update_scenes(\n",
+    "        xaxis_title='x (Å)', yaxis_title='y (Å)', zaxis_title='z (Å)',\n",
+    "        aspectmode='cube',\n",
+    "        camera=dict(eye=dict(x=1.5, y=1.5, z=1.5)),\n",
+    "    )\n",
+    "    fig.update_layout(\n",
+    "        height=500, width=800,\n",
+    "        title_text=f'<b>GOAC Optimized Structure — {len(best_structure)} atoms</b>',\n",
+    "        showlegend=True,\n",
+    "    )\n",
+    "    fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**▲ Figure 2 — Optimized structure in 3D.** Interactive view of the best configuration found by random sampling. Li in purple, In in blue, Cl in orange. Drag to rotate, scroll to zoom. The structure respects all crystallographic constraints while minimizing Coulomb energy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Figure 3: GEMDAT Occupancy → GOAC Configuration (3D Overlay)\n",
+    "\n",
+    "> **Takeaway:** GEMDAT tells us *where Li might be* (probability). GOAC tells us *where Li should be* (the specific arrangement that minimizes Coulomb energy). Ghost spheres show all Li candidates colored by occupancy; solid spheres show the GOAC-selected configuration. The selected Li atoms tend to sit at or near the highest-occupancy sites — validating the trajectory-derived occupancy with a physics-based energy criterion.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_30448/1930820756.py:9: UserWarning: The default value of primitive was changed from True to False in https://github.com/materialsproject/pymatgen/pull/3419. CifParser now returns the cell in the CIF file as is. If you want the primitive cell, please set primitive=True explicitly.\n",
+      "  best_structure = parser.parse_structures()[0]\n",
+      "/tmp/ipykernel_30448/1930820756.py:9: UserWarning: Issues encountered while parsing CIF: 2 fractional coordinates rounded to ideal values to avoid issues with finite precision.\n",
+      "  best_structure = parser.parse_structures()[0]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "#d4a017",
+          "opacity": 0.2,
+          "size": 7
+         },
+         "mode": "markers",
+         "name": "Cl",
+         "type": "scatter3d",
+         "x": {
+          "bdata": "+0w9LQ1E+T9KCG4pOyQrQARNlZJSVBJAbW+CYvGSMEDQLkeQLD4lQJSzAAbznDZAoEdCdl+W+T9MgYJqhS4rQGvWKTWJOCVAYQdyWCGaNkB3KAmP34b6PxQ3j2WVTCtAJwG92dV2+D9+2PE2lAorQAUsS8fB2RFALeevL010MEAxnAL5akP4P9+L2tomBCtAEQpj3S4BEkCw3jV1KH4wQLeqszL7TyVAh/E2V9qlNkAxqjSjFDz7P5/NIBA8YytAyhsdjm0FHkAfY2QhOH8zQNlSy2so1SRAmMXC83BoNkDP1c1Xm8oRQHZ+yo+DcDBAj/fd8wWGHkAQmtQ6Xp8zQIvaPAlRXhJApT8m/HCVMECl84RvsukeQBVZvllJuDNAHXe8qlrPHUDyOYxos3EzQG2ZrQ/D9iRA4+izRT55NkDthmzymFMeQOc9ePrCkjNAd9rF7eH5JEBnCcC0zXo2QDglHmoReBJAeqVkGOGbMEAlAqXo2RseQLVcBjjThDNAKzJCDT3n+D+dfmIdoRgrQFMw8GgnihFAQCgZmGZgMEBMwcYLpx8lQNJ8wEOwjTZAeaw3bd4s+T/nLWFJVSErQGbFt7Z4SSVAtesyFZmiNkDs3i198Cj7P4gabJPXYCtAye4vT++v9z8yNqBlt/EqQJ2iH/gB+hFA0wTlO118MEBkus346an2P6Xv07r20CpA7hIsP4g/EkDnIKjNvo0wQFljOX4FWCVA2M35fN+pNkBYHY9BD/74PwMc7GN7GytAYkgokkAVHkBFLmfiLIMzQCVU3bIcLyVAPsZLF2uVNkAiqLjpcp0SQDVGS3g5pTBApezMH3x9HkBVV9DFO50zQEtpyhXiRRJAfrZPQ1WPMEDt2qmfqTseQBCmzSnHjDNAYd4ASriwHkDEU13QCqozQMqmyL+Z/yRAaFy7mal9NkCZOc1AnL0dQJJqEM5DbTNAX+XBfCT7JEDbDj78bns2QJfcko3V9hFAUtNBIZJ7MEAmxlKlVVAeQLXNMSfykTNA",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "qXPZMu3w/D+pc9ky7fD8Pxaniz7bPB1AFqeLPts8HUCa6sQegn/8P5rqxB6Cf/w/5V05vpIgHUDlXTm+kiAdQBcJ8N4viCJAFwnw3i+IIkBBNLn9tu4NQEE0uf227g1Ahc6VwbSdIkCFzpXBtJ0iQFFm34HTAg5AUWbfgdMCDkA53YvLQL25Pzndi8tAvbk/HK+mvjhfFkAcr6a+OF8WQB4J9hVe67E/Hgn2FV7rsT930qpeo2EWQHfSql6jYRZA9A/DP4Wx/D/0D8M/hbH8P21Tx3/XMh1AbVPHf9cyHUC7HCwnkgX9P7scLCeSBf0/0vZNHQdFHUDS9k0dB0UdQDnPdX7kgiJAOc91fuSCIkAWoTi5EWsOQBahOLkRaw5AoDf1gDx2IkCgN/WAPHYiQPVVpCZvRw5A9VWkJm9HDkAVxKm9XTi2PxXEqb1dOLY/rgPIXpCJFkCuA8hekIkWQFRSDXxjmcA/VFINfGOZwD/8VIvgs1kWQPxUi+CzWRZA0M0+HSd3/D/QzT4dJ3f8P9aaV2N9Lh1A1ppXY30uHUBhEPlUVpr8P2EQ+VRWmvw/KrEjn+RVHUAqsSOf5FUdQBLALH9ybyJAEsAsf3JvIkCGYiMheZIOQIZiIyF5kg5ANPC2AYdwIkA08LYBh3AiQK6Ck393Fg5AroKTf3cWDkAUeLFc0421PxR4sVzTjbU/R4BxYW4MFkBHgHFhbgwWQCY0MW9k3a0/JjQxb2TdrT+2oPeB4ysWQLag94HjKxZAZO7Nhemm/T9k7s2F6ab9PxhMWZz6PB1AGExZnPo8HUBniik4+eb9P2eKKTj55v0/zEo2Ic0YHUDMSjYhzRgdQHFkgsFejyJAcWSCwV6PIkABZPzZOk0OQAFk/Nk6TQ5AvSGLfleUIkC9IYt+V5QiQGZAi/ikmg5AZkCL+KSaDkCpMmrdjeCfP6kyat2N4J8/73AcordGFkDvcByit0YWQE8GjS2sk7A/TwaNLayTsD82r0O9agUWQDavQ71qBRZA",
+          "dtype": "f8"
+         },
+         "z": {
+          "bdata": "K9mmAOWQ8T9Mcl/7qMUJwGDb7EEr0a4/UXSJYWsJEcByF/Dkn9QcQNSSxVkkGwdAYiW3c7PaJEC8/GAvWW4YQNXxhEUKzRxAmEfvGvkLB0CuaTCvFvgkQL2mH6wfqRhAwk9tY5Kt8j8w9GM+UjcJwKDSgMmQ6ac/Y0x6ljoXEcDQAiq1e0MlQJe3RrLpPxlAWzIcp58rI0CuFiuWMRAVQHwx3i2xPQHAxWb8TublGcACRnIMfMLwPxB54WndLArAYmbuSrMm7b/UGmsh5OsUwOgS/MqITADAfFeLHVJtGcBWfTqpjAsjQA3OM6AL0BRAifBHX0/wIEAKk4IGkZkQQLdU+P7sESNA0HyvS8zcFEDlQAWtmsIgQMMz/aEnPhBAvkHYaTpT7r8/VkgFdREVwKTlJmyBAgDA28Agbk5IGcBUlW4p8QYhQJ/cz5rUxhBA3Jlwl1j3HECol8a+lWAHQBD1oMOnRbC/3NEbVySIEcC3dXtT/bLwv3Yr7AzNcxXAtoSPshwQHkBebQT1HZIJQBJ6C4IEXRlAFFj8k+0rAEDU/Z2F9OjtP5wcs07eEwvAubPYpb/9EECAkyaNhFOyvwRbGnVM6e4/fsI7R8jTCsD2u8Qj08AQQGBvlkJTx8C/mALKIrvRHUAgaXnVWhUJQEJm/36KQxlA6GDIG/Px/z+xkDPlJvoQQMBVb7a0ObO/ZeAMTeUfCUBYdxtGbNzyv/vE2TC1WxBAoCFx5hBrzb+6PrCHmKgdQGLhRZ8VwwhA7oHXFHG8FEAwn1HmGqvrP+C1Dy1njhBAQAWzX9EUx78+4mssZqEIQKhzXYdq2fO/iyWMEVkLAECEdo5ewoICwARohqMZJAhAGGgomQPU9L/6nloS1zAAQOo/WGlEXQLA6RuLOtv/FEAQb+4TbMbtP3ThwWZOFBFAAJalv6Vfqb9BBr8DNCcBQNCVW2znZgHACv0TmgyX8T+MnRAjlcIJwBnRxkmIoRhARAzmRupp/T9ArxK30ZsUQMAJK/gfpuo/",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#3366cc",
+          "opacity": 0.2,
+          "size": 12
+         },
+         "mode": "markers",
+         "name": "In",
+         "type": "scatter3d",
+         "x": {
+          "bdata": "qZuc6Gr2J0AAaisyEvk3QKkFXAl9JQhAwjkRvhgFLkC8xZTJan0YQJtNQnA3HTJAKSAgnq86IkBBLO2MNBs1QOcMIxn8eLc/H1jga6sqKEAWCkvRiK4IQN76DLBbJy5AJHFrsPE7GEB0+Pcp2QwyQP8fdKUqGiJAAhmRDPIKNUA=",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "CqI2MkyhmT8KojYyTKGZP/B0I30ZaBZA8HQjfRloFkC5TcJasMm+P7lNwlqwyb4/sOyo3I0MFkCw7KjcjQwWQDYSaZIZ+8A/NhJpkhn7wD8lVlUDMyoWQCVWVQMzKhZApsr2XxfXJUCmyvZfF9clQC3QEcO/LBZALdARw78sFkA=",
+          "dtype": "f8"
+         },
+         "z": {
+          "bdata": "DBDeBHEBEcAKr3VePyQhwEPQx5GyHvC/GUJ/XLpOFcDrVnuSOMUkQM5f6WxjQxhAIlNE+NK7CcCady809yQewNcXOv64aRlAcNbxl1ZFAEDti+Yc7DEVQCDvySbzVu8/QHh3dSFiEUAAOSpqvRObP17klKlZHglAxOnadYPf8r8=",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "cmax": 1,
+          "cmin": 0,
+          "color": {
+           "bdata": "AAAAAAAA6D8AAAAAAADoPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADgPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADgPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADgPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADgPwAAAAAAAOg/AAAAAAAA6D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA6D8AAAAAAADoPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADgPwAAAAAAAOA/AAAAAAAA6D8AAAAAAADoPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADgPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADgPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADgPwAAAAAAAOA/AAAAAAAA4D8AAAAAAADgPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADgPwAAAAAAAOA/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+           "dtype": "f8"
+          },
+          "colorbar": {
+           "len": 0.6,
+           "thickness": 15,
+           "title": {
+            "text": "GEMDAT<br>occupancy"
+           },
+           "x": 1.02
+          },
+          "colorscale": [
+           [
+            0,
+            "#0d0887"
+           ],
+           [
+            0.1111111111111111,
+            "#46039f"
+           ],
+           [
+            0.2222222222222222,
+            "#7201a8"
+           ],
+           [
+            0.3333333333333333,
+            "#9c179e"
+           ],
+           [
+            0.4444444444444444,
+            "#bd3786"
+           ],
+           [
+            0.5555555555555556,
+            "#d8576b"
+           ],
+           [
+            0.6666666666666666,
+            "#ed7953"
+           ],
+           [
+            0.7777777777777778,
+            "#fb9f3a"
+           ],
+           [
+            0.8888888888888888,
+            "#fdca26"
+           ],
+           [
+            1,
+            "#f0f921"
+           ]
+          ],
+          "line": {
+           "width": 0
+          },
+          "opacity": 0.4,
+          "size": {
+           "bdata": "AAAAAAAAKEAAAAAAAAAoQAAAAAAAAC5AAAAAAAAALkAAAAAAAAAiQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAiQAAAAAAAAC5AAAAAAAAALkAAAAAAAAAiQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAiQAAAAAAAAChAAAAAAAAAKEAAAAAAAAAuQAAAAAAAAC5AAAAAAAAAKEAAAAAAAAAoQAAAAAAAAC5AAAAAAAAALkAAAAAAAAAiQAAAAAAAACJAAAAAAAAAKEAAAAAAAAAoQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAiQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAiQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAuQAAAAAAAAC5AAAAAAAAALkAAAAAAAAAuQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAiQAAAAAAAACJAAAAAAAAAIkAAAAAAAAAiQAAAAAAAAC5AAAAAAAAALkAAAAAAAAAiQAAAAAAAACJAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEAAAAAAAAAIQAAAAAAAAAhAAAAAAAAACEA=",
+           "dtype": "f8"
+          }
+         },
+         "mode": "markers",
+         "name": "Li candidates (GEMDAT)",
+         "type": "scatter3d",
+         "x": {
+          "bdata": "////X7qJAED/DSYPT6AtQAAAACD5IxlA/waTg+4HM0AAAABgQyIhQAAHk+sRUDVAVzEnYPr0NkD///8/YnAnQAAAAMAxQBVA/waTq/wOMkBYMSegt+c2QP7//7/cVSdAWDEngEzDNEABAACABg0jQFkxJ9BtyDRAAAAAIEkXI0AAAAAgkM0gQAAHk0u4JTVAWDi6rzT0NUAADibf1m4lQAAAAGAcMQJAAQ4mjycKLkAAAACAayAhQP8Gk/slTzVAAAAAAEGLEEAAB5N7wOEwQBAAAIDxYc4/AA4mPWj3KUACAADgF8kYQAAHkzM28TJA////X16AGEAAB5PTB98yQP///1/TfAFA/w0mTxXdLUAAAACAgssAQAEOJhfBsC1AVzEnoJHHNED///+/kBUjQP///x+QfRVAAAeTQ1QeMkDv//8fx7rAPwEOppPLwClAAAAAgAeUFUD/BpMb8iMyQAgAAICRl9I/AA4mA50SKkACAACgsQsKQAAHk29mADBA////P2PR8T8ADibfDLgrQP7//3/HKRFA/waTG2IJMUD///8/lDMeQAAHk0vVSzRAWDi690r0NUAADiZvA28lQP3//1+KKx5A/waT09JJNEBXOLqBdP01QAAOJoNWgSVAAAAAYNev8D/+DSZj25MrQAAAAGAluxBA/waTk7ntMEBYOLprm841QAAOJlekIyVACAAAoJaR7z8BDibh+XYrQAEAAGASgyVAAAeTa3mAN0AAAACAivHzPwEOJscR/CtA////n8l6HUAAB5Ojoh00QAAAAMAV+yRAAAeTG3s8N0D4//9/uaTuP/8NJg8saCtA////3548EUAAB5PzFw4xQAIAACD0bPE//g0m+36rK0ACAADgX7kRQP8GkzNILTFAAAAA4KRUHUD/BpNzGRQ0QP///79tFCVA/waTGydJN0D+///f1v0QQAAHk/Nl/jBAAQAAwE+nHUAAB5MrxCg0QP///59adhFA/waT44YcMUD+//8f8b0dQAAHk4NsLjRAWDi65ZLmNkD/DSZLk1MnQP7//79GoP8/AA4mT+lxLUD///+/fT0jQAAHkxuvXTZA3///X6HnpD8ADoYYyJIpQAAAAABoXyNA/waTO6RuNkD////fpL7GPwAOpgrb2ClAVzi6vY3ZNkAADib7iDknQP7//z/gswBAAA4mh9iqLUBYOLrArOA3QAAOJgHHRylAAQAAwIjSCUD/DSangvIvQAAAAOAfTyFA/waTK4BmNUBYOLqRr/A2QAAOJqPMZydAAAAAQJhGFUAAB5NLlhAyQAAAAMALICFAAAeTG/ZONUD/////Hq4KQP8Gkxu0FDBA/f//f6f3GUD/BpMb2jwzQAAAAIDQMwpA/waTS2oFMEACAADAX7MZQAAHkyvIKzNAAAAAYATCFUD/BpNTcS8yQAAAACCo3CBAAAeTS0QtNUABAABACRMZQP8Gk4uyAzNAAAAAAJH+IkAAB5O7OD42QAEAAKC1GwFAAA4m383ELUAAAACAPIkVQAAHk1s/ITJA9G/TtRZtKUAiaiisIZz3PwAAAED0cglAAQ4mh53aL0D///9/KO0BQAAOJpcq+S1A82/TNa1UI0D6vnzWRmk2QFg4ukui6jVA/w0mF7JbJUACAAAgO7bxPwEOJtuntCtA////X8HoEED/BpOTIPkwQP///19Tzh1AAAeTE4UyNEA=",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "AQAAQBpjDkABAABAGmMOQAAAAMCAbA5AAAAAwIBsDkABAADgi8QOQAEAAOCLxA5AAAAAAHdUIkAAAAAAd1QiQAEAAMCSnSJAAQAAwJKdIkABAAAAU7/+PwEAAABTv/4/AQAAwKkoFkABAADAqSgWQAAAAADsI/0/AAAAAOwj/T8AAACgQl6yPwAAAKBCXrI/AAAA4GRQHUAAAADgZFAdQAIAAIAbrR1AAgAAgButHUAAAADgJi4dQAAAAOAmLh1AAAAAIHXCDEAAAAAgdcIMQP///18uYg5A////Xy5iDkAAAACgfxawPwAAAKB/FrA/AAAA4OYpHUAAAADg5ikdQOhCAqgFM60/6EICqAUzrT8AAAAAqzgdQAAAAACrOB1AAAAA4FeQIkAAAADgV5AiQAIAAMCyUvw/AgAAwLJS/D8AAAAgBT0dQAAAACAFPR1AAAAAQD1BFkAAAABAPUEWQN6EBFCLAp0/3oQEUIsCnT////+f8hP+P////5/yE/4/AAAAQO3w/D8AAABA7fD8PwAAAEDbPB1AAAAAQNs8HUAAAAAggn/8PwAAACCCf/w/AAAAwJIgHUAAAADAkiAdQAAAAOAviCJAAAAA4C+IIkAAAAAAt+4NQAAAAAC37g1AAAAAwLSdIkAAAADAtJ0iQAAAAIDTAg5AAAAAgNMCDkACAABgQL25PwIAAGBAvbk/AQAAwDhfFkABAADAOF8WQAAAAIBe67E/AAAAgF7rsT8BAABgo2EWQAEAAGCjYRZAAAAAQIWx/D8AAABAhbH8PwEAAIDXMh1AAQAAgNcyHUAAAAAgkgX9PwAAACCSBf0/AQAAIAdFHUABAAAgB0UdQAEAAIDkgiJAAQAAgOSCIkAAAADAEWsOQAAAAMARaw5AAAAAgDx2IkAAAACAPHYiQAAAACBvRw5AAAAAIG9HDkABAAAgXji2PwEAACBeOLY/AgAAYJCJFkACAABgkIkWQAAAACBjmcA/AAAAIGOZwD8AAADgs1kWQAAAAOCzWRZAAAAAICd3/D8AAAAgJ3f8PwIAAGB9Lh1AAgAAYH0uHUAAAABgVpr8PwAAAGBWmvw/AAAAoORVHUAAAACg5FUdQAAAAIBybyJAAAAAgHJvIkABAAAgeZIOQAEAACB5kg5AAAAAAIdwIkAAAAAAh3AiQAEAAIB3Fg5AAQAAgHcWDkAAAADA0o21PwAAAMDSjbU/AAAAYG4MFkAAAABgbgwWQDlCAqhl3a0/OUICqGXdrT8AAACA4ysWQAAAAIDjKxZAAQAAgOmm/T8BAACA6ab9PwAAAKD6PB1AAAAAoPo8HUACAABA+eb9PwIAAED55v0/AAAAIM0YHUAAAAAgzRgdQAEAAMBejyJAAQAAwF6PIkABAADgOk0OQAEAAOA6TQ5AAAAAgFeUIkAAAACAV5QiQAEAAAClmg5AAQAAAKWaDkAXhQRQi+CfPxeFBFCL4J8/AQAAoLdGFkABAACgt0YWQAAAACCsk7A/AAAAIKyTsD8BAADAagUWQAEAAMBqBRZAi4UEUEuhmT+LhQRQS6GZPwEAAIAZaBZAAQAAgBloFkAAAADgr8m+PwAAAOCvyb4/AQAA4I0MFkABAADgjQwWQAAAAOAZ+8A/AAAA4Bn7wD8AAAAAMyoWQAAAAAAzKhZAAAAAYBfXJUAAAABgF9clQAEAAMC/LBZAAQAAwL8sFkA=",
+          "dtype": "f8"
+         },
+         "z": {
+          "bdata": "AAAAoGasCED9//+fZqwIQAAAACC2HSJANfpFRwV7DMD///9fuokHQPz//1+6iQdAEZwaUOmhFsAAAABAZNgHQAEAAMAwmQhA////vzCZCEARnBoA+oUWwP///99CEAhA7j5W/jTy1j8AAABgn/4hQPc+Vv7kntM/AAAA4ATkIUD+////8wkJQPz////zCQlAJDg1oMeOBcD///+ft8YXQP7//1/lkCdA7+gXHSG56r////+/f+UHQP3//79/5QdA////34zIGED+///fjMgYQAAAAIAM+yFAN/pFx6sFDcD+///f6gkiQDf6RUcyygzAAAAAIIYCIkA4+kVHxecMwP///7+PjghA////v4+OCED/////P+oIQP////8/6ghA/j5W/txh1D8AAACgHOohQP3///8R1AhA/////xHUCEAAAADgRNghQDL6RUfKkA3A/v///+VFCED+////5UUIQAAAAOAgwyFANfpFR1rlDcD6///fEjCzPxwAAOASMLM/////n7sW+T/5//+fuxb5PwAAAACYwPk/AwAAAJjA+T89+kXHZeYBwD76Rcdl5gHAwY+VP8Zp+z84+kXHwyACwDf6RcdP/AHANvpFx0/8AcDCj5U/d5j8Pzb6RUdriQHA/v//HwXd+T8CAAAgBd35P/7//1975vg/AAAAYHvm+D+5j5U/kAv+PzT6RcfezwDA/v//fzgWJUA5+kXH+5gAwAEAAOCWVvk/9P//35ZW+T////8/WP/4P/b//z9Y//g/////H1/7+j8CAAAgX/v6P////19hz/k/9v//X2HP+T8AAAAAzO4kQDT6RcetNgHA////H8AbJUA4+kVH3YIAwAAAAADTDSVANPpFx5G6AMD///9fowElQD36RUdQ6wDA/v//P7Mk+j8CAABAsyT6P/3//7/Htfo/BwAAwMe1+j////+/fyglQDn6RcfeTwDAN/pFx6IBAsA6+kXHogECwP3///8mFPg/AAAAACcU+D8AAADgSxr5P////99LGvk/RHBqQBil8L8AAABg1WQeQP///391zh1AG/2iY3mqFMAAAAAgo9URQP///x+j1RFA////v2EeEkAAAADAYR4SQP3//78gEBJA/f//vyAQEkD///9/GxASQP7//38bEBJARXBqwFn58b//////xA8eQP///z9l3B1AHP2io4mcFMAQnBrQlKkQwP7//5+G5BFA/v//n8QAEkD9//+fxAASQP///99E2x1AG/2iA6qdFMBIcGrA7CLyv////z9gBR5A////Pyy0HUAb/aKjwsQUwP///7887x1AHv2iI7KJFMAAAADgFuURQP///98W5RFAAAAAIFLhEUD///8fUuERQP///994jBFA////33iMEUD+//+/ptwRQP7//7+m3BFA////v0goHkAb/aIjplAUwP///98DTR5AGv2iA+srFMD///+f0yUSQP7//5/TJRJA////P45bEkD///8/jlsSQP7//9/lQh1AHP2iAwk2FcAAAADAgKkdQB79oiNuzxTAyZgFe7Hyrj+gU4hpAGYhQOj//z8FMrM/s///PwUysz/c6BcdIbnov+DoFx0huei/l5gFe9H4rz95mAV70fivPyE4NWANCwXAAAAAwJQIGED////ffB8YQP7//998HxhA////3zuRGED+///fO5EYQP///9/UFRhAG/2iAxpjGsA=",
+          "dtype": "f8"
+         }
+        },
+        {
+         "marker": {
+          "color": "#cc33cc",
+          "line": {
+           "color": "black",
+           "width": 1
+          },
+          "opacity": 0.95,
+          "size": 8
+         },
+         "mode": "markers",
+         "name": "Li placed (GOAC, n=35)",
+         "type": "scatter3d",
+         "x": {
+          "bdata": "D+Z+hDn3IUAzjxyAefk0QAggCXpMKRhALGRf3C8IMkBHB67ZFu4hQM8ftCro9DRA4YatvbGHGEDkfUgtyR8yQLca+1CYPghABv/4j18LLkB5o79799WVPygYeHekBihAsb2I8pFDCkDEZ1z4nYwuQCY7ubs5HSJASmcKxn8SKEAVOy09HnJ0P6+3ivyOBShAo9MX034PNUB5y9av+IUuQEMGtADExSFAnwXdEmPONEBoTOasTy0uQJ63Mo8dGTJAptMq+VEsCUBHNu4/D2oYQEsT1HUrtQhAugYT/L7rB0AG+r46qfYtQCY/c3Nu8ZQ/ShgAOzIGKEBed/D83+W6P0kZtDuFMShA0ajunbj2F0CJ2V7pivsxQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "02GvwYBsDkDTYa/BgGwOQD4/R7+SnSJAPj9Hv5KdIkBM/eBIQ16yP0z94EhDXrI/6qo/ghutHUDqqj+CG60dQPh4oM0pOB1A+HigzSk4HUDmh63gV5AiQOaHreBXkCJAbG3MpIsCnT9sbcykiwKdP652U+KLxA5Aam9VAXdUIkDo+Vf2Ur/+P6+LTsGpKBZAaRQ03yYuHUCy1O9kLmIOQBr4B1aAFrA/JJ7q3uYpHUBvjEdWBDOtP+M0Kr6yUvw/dxGoHwU9HUBVavU/PUEWQJpV/6XyE/4/9fI7RhpjDkD18jtGGmMOQHttv/LrI/0/e22/8usj/T96gOvdZFAdQHqA691kUB1A7fhaHHXCDEDt+FocdcIMQA==",
+          "dtype": "f8"
+         },
+         "z": {
+          "bdata": "H2PZb4ORGUAwKphv65QAQJ2+b/q4evE/wLzi8r7QCcDu1pTemva4P6z6kkwz4xDAkbBYgluhJEAZE6RMqfsXQHGRNWHKvwFAmgrlDlHOAMDKLhtRngYjQI0PKeouxhRAANmzq6iDIEDux7Q+h4APQAHJmsSQScG/hgeDzTKt8r8xKLbXBZAJQFXMfs+Q8hRATotE0+6kEcDlmnE87TsQQEEk2+YQixlAphobvX2dAECI8w5jq2ABwMNbKKnxwgnA9QpVjEazIEBSF8mgWmzwP7zQaK5VhvC/IvcpwuSbAUDvpPCtNvIAwIxbkqBNACNAqEdLg425FECbh7/3xx4ZQEfmyP7oXv8/6/QRPty1EUAPXyEOoLO7Pw==",
+          "dtype": "f8"
+         }
+        }
+       ],
+       "layout": {
+        "height": 600,
+        "legend": {
+         "x": 0,
+         "y": 1
+        },
+        "scene": {
+         "aspectmode": "data",
+         "camera": {
+          "eye": {
+           "x": 1.4,
+           "y": 1.4,
+           "z": 1.1
+          }
+         },
+         "xaxis": {
+          "title": {
+           "text": "x (Å)"
+          }
+         },
+         "yaxis": {
+          "title": {
+           "text": "y (Å)"
+          }
+         },
+         "zaxis": {
+          "title": {
+           "text": "z (Å)"
+          }
+         }
+        },
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "<b>GEMDAT occupancy → GOAC configuration (2×1×1 supercell)</b>"
+        },
+        "width": 950
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ 160 Li candidate positions (GEMDAT) → 35 Li placed (GOAC)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "import numpy as np\n",
+    "from pymatgen.io.cif import CifParser\n",
+    "\n",
+    "# ── 1. Load the best GOAC structure ──\n",
+    "best_cif = output_dir / 'li_in_cl_optimized-0.cif'\n",
+    "if best_cif.exists():\n",
+    "    parser = CifParser(str(best_cif))\n",
+    "    best_structure = parser.parse_structures()[0]\n",
+    "else:\n",
+    "    best_structure = input_structure\n",
+    "\n",
+    "sup_lattice = best_structure.lattice\n",
+    "\n",
+    "# ── 2. Occupancy data from GEMDAT (unit cell), tiled to supercell ──\n",
+    "occ_structure = transitions.occupancy()\n",
+    "occ_lattice = occ_structure.lattice\n",
+    "a_vec = occ_lattice.matrix[0]  # first lattice vector (tiling direction)\n",
+    "\n",
+    "li_occ_vals = []\n",
+    "li_occ_coords = []\n",
+    "for site in occ_structure.sites:\n",
+    "    cart = occ_lattice.get_cartesian_coords(site.frac_coords)\n",
+    "    occ = site.species.num_atoms\n",
+    "    for ix in range(supercell[0]):\n",
+    "        li_occ_coords.append(cart + ix * a_vec)\n",
+    "        li_occ_vals.append(occ)\n",
+    "\n",
+    "li_occ_vals = np.array(li_occ_vals)\n",
+    "li_occ_coords = np.array(li_occ_coords)\n",
+    "\n",
+    "# ── 3. Wrap all positions into the supercell using minimum-image convention ──\n",
+    "# Convert to fractional coords of the supercell lattice, wrap to [0,1), convert back.\n",
+    "# This ensures GEMDAT ghost spheres and GOAC atoms live in the same periodic image,\n",
+    "# regardless of any origin shift introduced when GOAC writes/reads CIF files.\n",
+    "li_occ_frac = sup_lattice.get_fractional_coords(li_occ_coords)\n",
+    "li_occ_frac = li_occ_frac % 1.0\n",
+    "li_occ_coords = sup_lattice.get_cartesian_coords(li_occ_frac)\n",
+    "\n",
+    "li_goac_coords = np.array([\n",
+    "    s.coords for s in best_structure if s.species.elements[0].symbol == 'Li'\n",
+    "])\n",
+    "li_goac_frac = sup_lattice.get_fractional_coords(li_goac_coords)\n",
+    "li_goac_frac = li_goac_frac % 1.0\n",
+    "li_goac_coords = sup_lattice.get_cartesian_coords(li_goac_frac)\n",
+    "\n",
+    "# ── 4. Framework atoms (In, Cl) from the supercell ──\n",
+    "in_coords = np.array([s.coords for s in best_structure if s.species.elements[0].symbol == 'In'])\n",
+    "cl_coords = np.array([s.coords for s in best_structure if s.species.elements[0].symbol == 'Cl'])\n",
+    "\n",
+    "# ── 5. Build 3D figure ──\n",
+    "fig = go.Figure()\n",
+    "\n",
+    "# Cl framework — faded background\n",
+    "if len(cl_coords):\n",
+    "    fig.add_trace(go.Scatter3d(\n",
+    "        x=cl_coords[:, 0], y=cl_coords[:, 1], z=cl_coords[:, 2],\n",
+    "        mode='markers',\n",
+    "        marker=dict(size=7, color='#d4a017', opacity=0.20),\n",
+    "        name='Cl',\n",
+    "    ))\n",
+    "\n",
+    "# In framework — faded background\n",
+    "if len(in_coords):\n",
+    "    fig.add_trace(go.Scatter3d(\n",
+    "        x=in_coords[:, 0], y=in_coords[:, 1], z=in_coords[:, 2],\n",
+    "        mode='markers',\n",
+    "        marker=dict(size=12, color='#3366cc', opacity=0.20),\n",
+    "        name='In',\n",
+    "    ))\n",
+    "\n",
+    "# Li candidates — ghost spheres sized and colored by GEMDAT occupancy\n",
+    "fig.add_trace(go.Scatter3d(\n",
+    "    x=li_occ_coords[:, 0], y=li_occ_coords[:, 1], z=li_occ_coords[:, 2],\n",
+    "    mode='markers',\n",
+    "    marker=dict(\n",
+    "        size=li_occ_vals * 12 + 3,\n",
+    "        color=li_occ_vals,\n",
+    "        colorscale='plasma',\n",
+    "        opacity=0.40,\n",
+    "        colorbar=dict(title='GEMDAT<br>occupancy', thickness=15, len=0.6, x=1.02),\n",
+    "        cmin=0, cmax=1,\n",
+    "        line=dict(width=0),\n",
+    "    ),\n",
+    "    name='Li candidates (GEMDAT)',\n",
+    "))\n",
+    "\n",
+    "# GOAC-selected Li — solid spheres\n",
+    "fig.add_trace(go.Scatter3d(\n",
+    "    x=li_goac_coords[:, 0], y=li_goac_coords[:, 1], z=li_goac_coords[:, 2],\n",
+    "    mode='markers',\n",
+    "    marker=dict(\n",
+    "        size=8, color='#cc33cc', opacity=0.95,\n",
+    "        line=dict(width=1, color='black'),\n",
+    "    ),\n",
+    "    name=f'Li placed (GOAC, n={len(li_goac_coords)})',\n",
+    "))\n",
+    "\n",
+    "fig.update_scenes(\n",
+    "    xaxis_title='x (Å)', yaxis_title='y (Å)', zaxis_title='z (Å)',\n",
+    "    aspectmode='data',\n",
+    "    camera=dict(eye=dict(x=1.4, y=1.4, z=1.1)),\n",
+    ")\n",
+    "fig.update_layout(\n",
+    "    height=600, width=950,\n",
+    "    title_text='<b>GEMDAT occupancy → GOAC configuration (2×1×1 supercell)</b>',\n",
+    "    showlegend=True,\n",
+    "    legend=dict(x=0, y=1),\n",
+    ")\n",
+    "fig.show()\n",
+    "\n",
+    "print(f'✓ {len(li_occ_coords)} Li candidate positions (GEMDAT) → {len(li_goac_coords)} Li placed (GOAC)')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**▲ Figure 3 — GEMDAT occupancy overlaid with GOAC configuration (interactive 3D).** Ghost spheres show all possible Li positions from the MD trajectory; size and color encode GEMDAT fractional occupancy (dark purple = low, yellow = high). Solid purple spheres are the Li atoms selected by GOAC for the lowest-energy Coulomb configuration. In and Cl framework atoms are shown faded in the background. Drag to rotate, scroll to zoom.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Workflow: **MD Trajectory → Site Occupancy (GEMDAT) → Random Sampling (GOAC)**.\n",
+    "\n",
+    "| Step | Tool | Output |\n",
+    "|------|------|--------|\n",
+    "| MD trajectory | GEMDAT | Li positions from LAMMPS trajectory |\n",
+    "| Site occupancy | GEMDAT | Li sites with partial occupancies from dynamics |\n",
+    "| Energy landscape | GOAC | Distribution of Coulomb energies from randomly sampled Li configurations (2×1×1 supercell) |\n",
+    "\n",
+    "GEMDAT captures *where Li might be* from the MD trajectory; GOAC samples the energy landscape over a supercell to reveal how strongly Li ordering affects the total electrostatic energy. The broad energy distribution shows that different Li arrangements have significantly different Coulomb energies — even in a small 2×1×1 supercell.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- [GEMDAT Documentation](https://gemdat.readthedocs.io/)\n",
+    "- [GOAC Repository](https://iffgit.fz-juelich.de/k.koester/goac.git)\n",
+    "- [Installation Guide](https://gemdat.readthedocs.io/en/latest/install_goac.html)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a notebook about [GOAC](https://iffgit.fz-juelich.de/k.koester/goac/-/tree/master/) and how to use it in combination with `gemdat`.

I have also prepared a small tool to install `goac` that is part of [this PR](https://github.com/GEMDAT-repos/GEMDAT/pull/403) to `gemdat`.

---
When [this other PR](https://github.com/GEMDAT-repos/GEMDAT/pull/402) is merged, this notebook should definitely be updated to use `write_cif`.