### PR TITLE
Replace broken install_goac link with install command from README

### DIFF
--- a/goac_integration_demo.ipynb
+++ b/goac_integration_demo.ipynb
@@ -3,42 +3,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# GOAC Integration with GEMDAT\n",
-    "\n",
-    "This notebook demonstrates how to integrate **GOAC** (Global Optimization of Atomistic Configurations by Coulomb) with **GEMDAT** for atomistic configuration optimization. GOAC uses a Coulomb energy-based approach to find the lowest-energy arrangement of atoms in materials with partially occupied sites (e.g., solid electrolytes with disordered Li). The workflow is: **MD Trajectory → Site Occupancy Analysis (GEMDAT) → Configuration Optimization (GOAC)**.\n",
-    "\n",
-    "See the [installation instructions](https://gemdat.readthedocs.io/en/latest/install_goac.html) to set up GOAC before running this notebook."
-   ]
+   "source": "# GOAC Integration with GEMDAT\n\nThis notebook demonstrates how to integrate **GOAC** (Global Optimization of Atomistic Configurations by Coulomb) with **GEMDAT** for atomistic configuration optimization. GOAC uses a Coulomb energy-based approach to find the lowest-energy arrangement of atoms in materials with partially occupied sites (e.g., solid electrolytes with disordered Li). The workflow is: **MD Trajectory → Site Occupancy Analysis (GEMDAT) → Configuration Optimization (GOAC)**.\n\nGOAC is an optional dependency of GEMDAT. It can be installed directly from GitHub:\n\n```console\npip install GOAC --find-links https://github.com/GEMDAT-repos/GOAC/releases/expanded_assets/0.1.1\n```"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Import GOAC and GEMDAT\n",
-    "\n",
-    "This notebook requires GOAC to be installed. Refer to the [installation instructions](https://gemdat.readthedocs.io/en/latest/install_goac.html) to set up GOAC before running this notebook."
-   ]
+   "source": "## Import GOAC and GEMDAT"
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "import numpy as np\n",
-    "import plotly.io as pio\n",
-    "\n",
-    "from gemdat import Trajectory\n",
-    "\n",
-    "pio.renderers.default = 'vscode'\n",
-    "\n",
-    "# If this fails, GOAC might not be installed, See https://gemdat.readthedocs.io/en/latest/install_goac.html\n",
-    "from GOAC.IterationProblem import Iteration_Problem\n",
-    "from GOAC.RandomSolver import Random_Solver"
-   ]
+   "source": "from pathlib import Path\n\nimport numpy as np\nimport plotly.io as pio\n\nfrom gemdat import Trajectory\n\npio.renderers.default = 'vscode'\n\n# If this fails, GOAC might not be installed, see the installation instructions above\nfrom GOAC.IterationProblem import Iteration_Problem\nfrom GOAC.RandomSolver import Random_Solver"
   },
   {
    "cell_type": "markdown",
@@ -3368,25 +3345,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "Workflow: **MD Trajectory → Site Occupancy (GEMDAT) → Random Sampling (GOAC)**.\n",
-    "\n",
-    "| Step | Tool | Output |\n",
-    "|------|------|--------|\n",
-    "| MD trajectory | GEMDAT | Li positions from LAMMPS trajectory |\n",
-    "| Site occupancy | GEMDAT | Li sites with partial occupancies from dynamics |\n",
-    "| Energy landscape | GOAC | Distribution of Coulomb energies from randomly sampled Li configurations (2×1×1 supercell) |\n",
-    "\n",
-    "GEMDAT captures *where Li might be* from the MD trajectory; GOAC samples the energy landscape over a supercell to reveal how strongly Li ordering affects the total electrostatic energy. The broad energy distribution shows that different Li arrangements have significantly different Coulomb energies — even in a small 2×1×1 supercell.\n",
-    "\n",
-    "### References\n",
-    "\n",
-    "- [GEMDAT Documentation](https://gemdat.readthedocs.io/)\n",
-    "- [GOAC Repository](https://iffgit.fz-juelich.de/k.koester/goac.git)\n",
-    "- [Installation Guide](https://gemdat.readthedocs.io/en/latest/install_goac.html)\n"
-   ]
+   "source": "## Summary\n\nWorkflow: **MD Trajectory → Site Occupancy (GEMDAT) → Random Sampling (GOAC)**.\n\n| Step | Tool | Output |\n|------|------|--------|\n| MD trajectory | GEMDAT | Li positions from LAMMPS trajectory |\n| Site occupancy | GEMDAT | Li sites with partial occupancies from dynamics |\n| Energy landscape | GOAC | Distribution of Coulomb energies from randomly sampled Li configurations (2×1×1 supercell) |\n\nGEMDAT captures *where Li might be* from the MD trajectory; GOAC samples the energy landscape over a supercell to reveal how strongly Li ordering affects the total electrostatic energy. The broad energy distribution shows that different Li arrangements have significantly different Coulomb energies — even in a small 2×1×1 supercell.\n\n### References\n\n- [GEMDAT Documentation](https://gemdat.readthedocs.io/)\n- [GOAC Repository](https://iffgit.fz-juelich.de/k.koester/goac.git)\n- [GOAC Releases](https://github.com/GEMDAT-repos/GOAC/releases)\n"
   }
  ],
  "metadata": {


### PR DESCRIPTION
The GOAC integration notebook linked to `https://gemdat.readthedocs.io/en/latest/install_goac.html`, which does not exist (see #21).

Changes:
- Intro cell now repeats the install command from the GEMDAT README (`pip install GOAC --find-links https://github.com/GEMDAT-repos/GOAC/releases/expanded_assets/0.1.1`) instead of linking to the nonexistent page.
- Removed the duplicate install mention under "Import GOAC and GEMDAT".
- The failed-import comment in the imports cell now points at the instructions above instead of the dead URL.
- References section links to the GOAC releases page instead of the dead "Installation Guide" link.

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)